### PR TITLE
Fix wrong fajr and sunrise time and crash at high time zones

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'salah'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=salah"
+                ],
+                "filter": {
+                    "name": "salah",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ license = "BSD-3-Clause"
 spectral = "0.6.0"
 
 [dependencies]
-chrono = "0.4.6"
+chrono = "0.4.10"
+serde = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ license = "BSD-3-Clause"
 spectral = "0.6.0"
 
 [dependencies]
-chrono = "0.4.10"
-serde = { version = "1.0", default-features = false, optional = true }
-schemars = { version = "0.7", optional = true }
+chrono = "0.4.18"
+serde = { version = "1.0.116", default-features = false, optional = true }
+schemars = { version = "0.8.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ spectral = "0.6.0"
 [dependencies]
 chrono = "0.4.10"
 serde = { version = "1.0", default-features = false, optional = true }
+schemars = { version = "0.7", optional = true }

--- a/examples/nexter.rs
+++ b/examples/nexter.rs
@@ -2,9 +2,9 @@ use salah::prelude::*;
 
 fn main() {
     let city = Coordinates::new(24.383_144, 88.583_183); // Rajshahi
-    let date = Utc::today();
+    let date = Local::today();
     let params = Parameters::with(Method::Karachi, Madhab::Hanafi);
-    let prayers = PrayerTimes::new(date, city, params);
+    let prayers = PrayerTimes::calculate(date, city, params);
 
     println!(
         "Fajr: {}",
@@ -106,6 +106,7 @@ fn main() {
 
     println!();
     println!("Now    : {}", Local::now().to_rfc3339());
+    println!();
 
     println!(
         "Current prayer: {} ({} minutes remaining)",
@@ -123,7 +124,7 @@ fn main() {
             .to_string()
     );
 
-    let t11am = Local::today().and_hms(5, 0, 0).with_timezone(&Utc);
+    let t11am = Local::today().and_hms(5, 0, 0).with_timezone(&Local);
     let pat11am = prayers.prayer_at(t11am);
 
     assert_eq!(pat11am, Prayer::Fajr);

--- a/examples/nexter.rs
+++ b/examples/nexter.rs
@@ -1,0 +1,146 @@
+use salah::prelude::*;
+
+fn main() {
+    let city = Coordinates::new(24.383_144, 88.583_183); // Rajshahi
+    let date = Utc::today();
+    let params = Parameters::with(Method::Karachi, Madhab::Hanafi);
+    let prayers = PrayerTimes::new(date, city, params);
+
+    println!(
+        "Fajr: {}",
+        prayers
+            .time(Prayer::Fajr)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+    println!(
+        "Sunrise: {}",
+        prayers
+            .time(Prayer::Sunrise)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+    println!(
+        "Dhuhr: {}",
+        prayers
+            .time(Prayer::Dhuhr)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+    println!(
+        "Asr: {}",
+        prayers
+            .time(Prayer::Asr)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+    println!(
+        "Maghrib: {}",
+        prayers
+            .time(Prayer::Maghrib)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+    println!(
+        "Isha: {}",
+        prayers
+            .time(Prayer::Isha)
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+
+    println!();
+
+    println!(
+        "Fajr   : {}",
+        prayers
+            .time(Prayer::Fajr)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+    println!(
+        "Sunrise: {}",
+        prayers
+            .time(Prayer::Sunrise)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+    println!(
+        "Dhuhr  : {}",
+        prayers
+            .time(Prayer::Dhuhr)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+    println!(
+        "Asr    : {}",
+        prayers.time(Prayer::Asr).with_timezone(&Local).to_rfc3339()
+    );
+    println!(
+        "Maghrib: {}",
+        prayers
+            .time(Prayer::Maghrib)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+    println!(
+        "Isha   : {}",
+        prayers
+            .time(Prayer::Isha)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+    println!(
+        "Qiyam  : {}",
+        prayers
+            .time(Prayer::Qiyam)
+            .with_timezone(&Local)
+            .to_rfc3339()
+    );
+
+    println!();
+    println!("Now    : {}", Local::now().to_rfc3339());
+
+    println!(
+        "Current prayer: {} ({} minutes remaining)",
+        prayers.current().name(),
+        prayers.time_remaining().num_minutes()
+    );
+
+    println!(
+        "Next prayer: {} @ {}",
+        prayers.next().name(),
+        prayers
+            .time(prayers.next())
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+
+    let t11am = Local::today().and_hms(5, 0, 0).with_timezone(&Utc);
+    let pat11am = prayers.prayer_at(t11am);
+
+    assert_eq!(pat11am, Prayer::Fajr);
+
+    println!(
+        "Prayer @ 11am: {} ({} minutes remaining)",
+        pat11am.name(),
+        (prayers.time(pat11am.next()) - t11am).num_minutes()
+    );
+
+    println!(
+        "Next prayer @ 11am: {} @ {}",
+        pat11am.next().name(),
+        prayers
+            .time(pat11am.next())
+            .with_timezone(&Local)
+            .format("%-l:%M %p")
+            .to_string()
+    );
+}

--- a/examples/nexter.rs
+++ b/examples/nexter.rs
@@ -8,101 +8,44 @@ fn main() {
 
     println!(
         "Fajr: {}",
-        prayers
-            .time(Prayer::Fajr)
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(Prayer::Fajr).format("%-l:%M %p").to_string()
     );
     println!(
         "Sunrise: {}",
         prayers
             .time(Prayer::Sunrise)
-            .with_timezone(&Local)
             .format("%-l:%M %p")
             .to_string()
     );
     println!(
         "Dhuhr: {}",
-        prayers
-            .time(Prayer::Dhuhr)
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(Prayer::Dhuhr).format("%-l:%M %p").to_string()
     );
     println!(
         "Asr: {}",
-        prayers
-            .time(Prayer::Asr)
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(Prayer::Asr).format("%-l:%M %p").to_string()
     );
     println!(
         "Maghrib: {}",
         prayers
             .time(Prayer::Maghrib)
-            .with_timezone(&Local)
             .format("%-l:%M %p")
             .to_string()
     );
     println!(
         "Isha: {}",
-        prayers
-            .time(Prayer::Isha)
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(Prayer::Isha).format("%-l:%M %p").to_string()
     );
 
     println!();
 
-    println!(
-        "Fajr   : {}",
-        prayers
-            .time(Prayer::Fajr)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
-    println!(
-        "Sunrise: {}",
-        prayers
-            .time(Prayer::Sunrise)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
-    println!(
-        "Dhuhr  : {}",
-        prayers
-            .time(Prayer::Dhuhr)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
-    println!(
-        "Asr    : {}",
-        prayers.time(Prayer::Asr).with_timezone(&Local).to_rfc3339()
-    );
-    println!(
-        "Maghrib: {}",
-        prayers
-            .time(Prayer::Maghrib)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
-    println!(
-        "Isha   : {}",
-        prayers
-            .time(Prayer::Isha)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
-    println!(
-        "Qiyam  : {}",
-        prayers
-            .time(Prayer::Qiyam)
-            .with_timezone(&Local)
-            .to_rfc3339()
-    );
+    println!("Fajr   : {}", prayers.time(Prayer::Fajr).to_rfc3339());
+    println!("Sunrise: {}", prayers.time(Prayer::Sunrise).to_rfc3339());
+    println!("Dhuhr  : {}", prayers.time(Prayer::Dhuhr).to_rfc3339());
+    println!("Asr    : {}", prayers.time(Prayer::Asr).to_rfc3339());
+    println!("Maghrib: {}", prayers.time(Prayer::Maghrib).to_rfc3339());
+    println!("Isha   : {}", prayers.time(Prayer::Isha).to_rfc3339());
+    println!("Qiyam  : {}", prayers.time(Prayer::Qiyam).to_rfc3339());
 
     println!();
     println!("Now    : {}", Local::now().to_rfc3339());
@@ -117,14 +60,10 @@ fn main() {
     println!(
         "Next prayer: {} @ {}",
         prayers.next().name(),
-        prayers
-            .time(prayers.next())
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(prayers.next()).format("%-l:%M %p").to_string()
     );
 
-    let t11am = Local::today().and_hms(5, 0, 0).with_timezone(&Local);
+    let t11am = Local::today().and_hms(5, 0, 0);
     let pat11am = prayers.prayer_at(t11am);
 
     assert_eq!(pat11am, Prayer::Fajr);
@@ -138,10 +77,6 @@ fn main() {
     println!(
         "Next prayer @ 11am: {} @ {}",
         pat11am.next().name(),
-        prayers
-            .time(pat11am.next())
-            .with_timezone(&Local)
-            .format("%-l:%M %p")
-            .to_string()
+        prayers.time(pat11am.next()).format("%-l:%M %p").to_string()
     );
 }

--- a/src/astronomy/ops.rs
+++ b/src/astronomy/ops.rs
@@ -4,7 +4,7 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
-use chrono::{DateTime, Datelike, Duration, DurationRound, Utc};
+use chrono::{Date, DateTime, Datelike, Duration, DurationRound, Utc};
 
 use crate::astronomy::unit::Normalize;
 use crate::astronomy::unit::{Angle, Coordinates};
@@ -296,8 +296,13 @@ pub fn julian_day_ymdh(year: i32, month: i32, day: i32, hours: f64) -> f64 {
 }
 
 // The Julian Day for the given Gregorian date.
-pub fn julian_day<Tz: chrono::TimeZone>(dt: &DateTime<Tz>) -> f64 {
-    julian_day_ymdh(dt.year() as i32, dt.month() as i32, dt.day() as i32, 0.0)
+pub fn julian_day<Tz: chrono::TimeZone>(date: Date<Tz>) -> f64 {
+    julian_day_ymdh(
+        date.year() as i32,
+        date.month() as i32,
+        date.day() as i32,
+        0.0,
+    )
 }
 
 // Julian century from the epoch.

--- a/src/astronomy/ops.rs
+++ b/src/astronomy/ops.rs
@@ -352,9 +352,7 @@ pub fn season_adjusted_morning_twilight(
     let adjustment = adjust(a, b, c, d, dyy);
 
     let rounded_adjustment = (adjustment * -60.0).round() as i64;
-    sunrise
-        .checked_add_signed(Duration::seconds(rounded_adjustment))
-        .unwrap()
+    sunrise + Duration::seconds(rounded_adjustment)
 }
 
 // Twilight adjustment based on observational data for use
@@ -374,9 +372,7 @@ pub fn season_adjusted_evening_twilight(
     let adjustment = adjust(a, b, c, d, dyy);
 
     let rounded_adjustment = (adjustment * 60.0).round() as i64;
-    let adjusted_date = sunset
-        .checked_add_signed(Duration::seconds(rounded_adjustment))
-        .unwrap();
+    let adjusted_date = sunset + Duration::seconds(rounded_adjustment);
 
     adjusted_date.duration_round(Duration::minutes(1)).unwrap()
 }

--- a/src/astronomy/ops.rs
+++ b/src/astronomy/ops.rs
@@ -314,6 +314,16 @@ pub fn is_leap_year(year: u32) -> bool {
     true
 }
 
+fn adjust(a: f64, b: f64, c: f64, d: f64, dyy: f64) -> f64 {
+    if (0.0..=90.0).contains(&dyy) { a + (b - a) / 91.0 * dyy } else if 
+        (91.0..=136.0).contains(&dyy) { b + (c - b) / 46.0 * (dyy - 91.0)} else if 
+        (137.0..=182.0) .contains(&dyy) { c + (d - c) / 46.0 * (dyy - 137.0)} else if 
+        (183.0..=228.0 ).contains(&dyy) { d + (c - d) / 46.0 * (dyy - 183.0)} else if 
+        (229.0..=274.0 ).contains(&dyy) { c + (b - c) / 46.0 * (dyy - 229.0)} else {
+        b + (a - b) / 91.0 * (dyy - 275.0)
+    }
+}
+
 // Twilight adjustment based on observational data for use
 // in the Moonsighting Committee calculation method.
 pub fn season_adjusted_morning_twilight(
@@ -328,14 +338,7 @@ pub fn season_adjusted_morning_twilight(
     let d = 75.0 + ((48.10 / 55.0) * latitude.abs());
 
     let dyy = days_since_solstice(day, year, latitude) as f64;
-    let adjustment = match dyy {
-        0.0...90.0 => a + (b - a) / 91.0 * dyy,
-        91.0...136.0 => b + (c - b) / 46.0 * (dyy - 91.0),
-        137.0...182.0 => c + (d - c) / 46.0 * (dyy - 137.0),
-        183.0...228.0 => d + (c - d) / 46.0 * (dyy - 183.0),
-        229.0...274.0 => c + (b - c) / 46.0 * (dyy - 229.0),
-        _ => b + (a - b) / 91.0 * (dyy - 275.0),
-    };
+    let adjustment = adjust(a,b,c,d,dyy);
 
     let rounded_adjustment = (adjustment * -60.0).round() as i64;
     sunrise
@@ -357,14 +360,7 @@ pub fn season_adjusted_evening_twilight(
     let d = 75.0 + ((6.140 / 55.0) * latitude.abs());
 
     let dyy = days_since_solstice(day, year, latitude) as f64;
-    let adjustment = match dyy {
-        0.0...90.0 => a + (b - a) / 91.0 * dyy,
-        91.0...136.0 => b + (c - b) / 46.0 * (dyy - 91.0),
-        137.0...182.0 => c + (d - c) / 46.0 * (dyy - 137.0),
-        183.0...228.0 => d + (c - d) / 46.0 * (dyy - 183.0),
-        229.0...274.0 => c + (b - c) / 46.0 * (dyy - 229.0),
-        _ => b + (a - b) / 91.0 * (dyy - 275.0),
-    };
+    let adjustment = adjust(a,b,c,d,dyy);
 
     let rounded_adjustment = (adjustment * 60.0).round() as i64;
     let adjusted_date = sunset

--- a/src/astronomy/ops.rs
+++ b/src/astronomy/ops.rs
@@ -4,7 +4,7 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
-use chrono::{Date, DateTime, Datelike, Duration, DurationRound, Utc};
+use chrono::{Date, DateTime, Datelike, Duration, DurationRound, Local};
 
 use crate::astronomy::unit::Normalize;
 use crate::astronomy::unit::{Angle, Coordinates};
@@ -346,8 +346,8 @@ pub fn season_adjusted_morning_twilight(
     latitude: f64,
     day: u32,
     year: u32,
-    sunrise: DateTime<Utc>,
-) -> DateTime<Utc> {
+    sunrise: DateTime<Local>,
+) -> DateTime<Local> {
     let a = 75.0 + ((28.65 / 55.0) * latitude.abs());
     let b = 75.0 + ((19.44 / 55.0) * latitude.abs());
     let c = 75.0 + ((32.74 / 55.0) * latitude.abs());
@@ -366,8 +366,8 @@ pub fn season_adjusted_evening_twilight(
     latitude: f64,
     day: u32,
     year: u32,
-    sunset: DateTime<Utc>,
-) -> DateTime<Utc> {
+    sunset: DateTime<Local>,
+) -> DateTime<Local> {
     let a = 75.0 + ((25.60 / 55.0) * latitude.abs());
     let b = 75.0 + ((2.050 / 55.0) * latitude.abs());
     let c = 75.0 - ((9.210 / 55.0) * latitude.abs());

--- a/src/astronomy/qiblah.rs
+++ b/src/astronomy/qiblah.rs
@@ -6,11 +6,14 @@
 
 use crate::astronomy::unit::{Angle, Coordinates};
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Qiblah(f64);
 
 impl Qiblah {

--- a/src/astronomy/qiblah.rs
+++ b/src/astronomy/qiblah.rs
@@ -6,14 +6,6 @@
 
 use crate::astronomy::unit::{Angle, Coordinates};
 
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[derive(PartialEq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 /// Qiblah
 pub struct Qiblah;
 

--- a/src/astronomy/qiblah.rs
+++ b/src/astronomy/qiblah.rs
@@ -6,6 +6,11 @@
 
 use crate::astronomy::unit::{Angle, Coordinates};
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Qiblah(f64);
 
 impl Qiblah {

--- a/src/astronomy/qiblah.rs
+++ b/src/astronomy/qiblah.rs
@@ -14,29 +14,32 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct Qiblah(f64);
+/// Qiblah
+pub struct Qiblah;
 
 impl Qiblah {
-    pub fn new(location_coordinates: Coordinates) -> Self {
+    /// Get Qiblah angle from a set of location coordinates
+    pub fn from_coords(location: Coordinates) -> f64 {
         // Equation from "Spherical Trigonometry For the use
         // of colleges and schools" page 50
         let makkah_coordinates = Coordinates::new(21.4225241, 39.8261818);
         let term1 = (makkah_coordinates.longitude_angle().radians()
-            - location_coordinates.longitude_angle().radians())
+            - location.longitude_angle().radians())
         .sin();
         let term2 = makkah_coordinates.latitude_angle().radians().tan()
-            * location_coordinates.latitude_angle().radians().cos();
+            * location.latitude_angle().radians().cos();
         let term3 = (makkah_coordinates.longitude_angle().radians()
-            - location_coordinates.longitude_angle().radians())
+            - location.longitude_angle().radians())
         .cos()
-            * location_coordinates.latitude_angle().radians().sin();
+            * location.latitude_angle().radians().sin();
         let term4 = term1.atan2(term2 - term3);
 
-        Qiblah(Angle::from_radians(term4).unwound().degrees)
+        Angle::from_radians(term4).unwound().degrees
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
     use spectral::prelude::*;
@@ -44,88 +47,88 @@ mod tests {
     #[test]
     fn qiblah_direction_from_nyc_in_north_america() {
         let nyc = Coordinates::new(40.7128, -74.0059);
-        let qiblah = Qiblah::new(nyc);
+        let qiblah = Qiblah::from_coords(nyc);
 
-        assert_that!(qiblah.0).is_close_to(58.4817635, 0.0000001f64);
+        assert_that!(qiblah).is_close_to(58.4817635, 0.0000001f64);
     }
 
     #[test]
     fn qiblah_direction_from_sf_in_north_america() {
         let sf = Coordinates::new(37.7749, -122.4194);
-        let qiblah = Qiblah::new(sf);
+        let qiblah = Qiblah::from_coords(sf);
 
-        assert_eq!(qiblah.0, 18.843822245692426);
+        assert_eq!(qiblah, 18.843822245692426);
     }
 
     #[test]
     fn qiblah_direction_from_dc_in_north_america() {
         let dc = Coordinates::new(38.9072, -77.0369);
-        let qiblah = Qiblah::new(dc);
+        let qiblah = Qiblah::from_coords(dc);
 
-        assert_eq!(qiblah.0, 56.56046821463599);
+        assert_eq!(qiblah, 56.56046821463599);
     }
 
     #[test]
     fn qiblah_direction_from_anchorage_in_north_america() {
         let dc = Coordinates::new(61.2181, -149.9003);
-        let qiblah = Qiblah::new(dc);
+        let qiblah = Qiblah::from_coords(dc);
 
-        assert_eq!(qiblah.0, 350.8830761159853);
+        assert_eq!(qiblah, 350.8830761159853);
     }
 
     #[test]
     fn qiblah_directioon_from_sydney_australia() {
         let sydney = Coordinates::new(-33.8688, 151.2093);
-        let qiblah = Qiblah::new(sydney);
+        let qiblah = Qiblah::from_coords(sydney);
 
-        assert_eq!(qiblah.0, 277.4996044487399);
+        assert_eq!(qiblah, 277.4996044487399);
     }
 
     #[test]
     fn qiblah_directioon_from_auckland_new_zealand() {
         let auckland = Coordinates::new(-36.8485, 174.7633);
-        let qiblah = Qiblah::new(auckland);
+        let qiblah = Qiblah::from_coords(auckland);
 
-        assert_eq!(qiblah.0, 261.19732640365845);
+        assert_eq!(qiblah, 261.19732640365845);
     }
 
     #[test]
     fn qiblah_direction_from_london_united_kingdom() {
         let london = Coordinates::new(51.5074, -0.1278);
-        let qiblah = Qiblah::new(london);
+        let qiblah = Qiblah::from_coords(london);
 
-        assert_that!(qiblah.0).is_close_to(118.9872189, 0.0000001f64);
+        assert_that!(qiblah).is_close_to(118.9872189, 0.0000001f64);
     }
 
     #[test]
     fn qiblah_direction_from_paris_france() {
         let paris = Coordinates::new(48.8566, 2.3522);
-        let qiblah = Qiblah::new(paris);
+        let qiblah = Qiblah::from_coords(paris);
 
-        assert_eq!(qiblah.0, 119.16313542183347);
+        assert_eq!(qiblah, 119.16313542183347);
     }
 
     #[test]
     fn qiblah_direction_from_oslo_norway() {
         let oslo = Coordinates::new(59.9139, 10.7522);
-        let qiblah = Qiblah::new(oslo);
+        let qiblah = Qiblah::from_coords(oslo);
 
-        assert_eq!(qiblah.0, 139.02785605537514);
+        assert_eq!(qiblah, 139.02785605537514);
     }
 
     #[test]
     fn qiblah_direction_from_islamabad_pakistan() {
         let islamabad = Coordinates::new(33.7294, 73.0931);
-        let qiblah = Qiblah::new(islamabad);
+        let qiblah = Qiblah::from_coords(islamabad);
 
-        assert_eq!(qiblah.0, 255.8816156785436);
+        assert_eq!(qiblah, 255.8816156785436);
     }
 
     #[test]
     fn qiblah_direction_from_tokyo_japan() {
         let tokyo = Coordinates::new(35.6895, 139.6917);
-        let qiblah = Qiblah::new(tokyo);
+        let qiblah = Qiblah::from_coords(tokyo);
 
-        assert_eq!(qiblah.0, 293.02072441441163);
+        assert_eq!(qiblah, 293.02072441441163);
     }
 }

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -5,18 +5,12 @@
 //
 
 use chrono::{Date, DateTime, Local, TimeZone, Utc};
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
 use crate::astronomy::ops;
 //use crate::astronomy::unit::Stride;
 use crate::astronomy::unit::{Angle, Coordinates};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SolarCoordinates {
     // The declination of the sun, the angle between
     // the rays of the Sun and the plane of the Earth's equator.
@@ -87,9 +81,7 @@ impl SolarCoordinates {
 }
 
 // Solar Time
-#[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Debug, Clone)]
 pub struct SolarTime {
     date: Date<Utc>,
     observer: Coordinates,

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -5,8 +5,10 @@
 //
 
 use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::astronomy::ops;
 use crate::astronomy::unit::Stride;
@@ -14,6 +16,7 @@ use crate::astronomy::unit::{Angle, Coordinates};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SolarCoordinates {
     // The declination of the sun, the angle between
     // the rays of the Sun and the plane of the Earth's equator.
@@ -85,6 +88,7 @@ impl SolarCoordinates {
 // Solar Time
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SolarTime {
     date: DateTime<Utc>,
     observer: Coordinates,
@@ -211,7 +215,11 @@ impl SolarTime {
             let adjusted_mins = (calculated_minutes + calculated_seconds / 60.0).round() as u32;
             let adjusted_secs: u32 = 0;
 
-            Some(adjusted_date.date().and_hms(adjusted_hour, adjusted_mins, adjusted_secs))
+            Some(
+                adjusted_date
+                    .date()
+                    .and_hms(adjusted_hour, adjusted_mins, adjusted_secs),
+            )
         } else {
             None
         }
@@ -333,5 +341,4 @@ mod tests {
 
         assert_eq!(sunrise_time, 10.131800480632849);
     }
-
 }

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -199,7 +199,7 @@ impl SolarTime {
             // Adjust the hour to be within 0..=23,
             // wrapping around as needed; otherwise
             // chrono method will panic.
-            let (adjusted_hour, adjusted_date) = if calculated_hours <= 0.0 {
+            let (adjusted_hour, adjusted_date) = if calculated_hours < 0.0 {
                 ((calculated_hours + 24.0) as u32, date.yesterday())
             } else if calculated_hours >= 24.0 {
                 ((calculated_hours - 24.0) as u32, date.tomorrow())
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn calculate_julian_date() {
-        let local = Local.ymd(1992, 10, 13).and_hms(0, 0, 0);
+        let local = Utc.ymd(1992, 10, 13).and_hms(0, 0, 0);
         let utc = local.with_timezone(&Utc);
         let julian_day = ops::julian_day(1992, 10, 13, 0.0);
 

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -32,7 +32,7 @@ pub struct SolarCoordinates {
 
 impl SolarCoordinates {
     fn new<Tz: TimeZone>(date: Date<Tz>) -> Self {
-        let julian_day = ops::julian_day(&date.and_hms(0, 0, 0));
+        let julian_day = ops::julian_day(date);
         let julian_century = ops::julian_century(julian_day);
         let mean_solar_longitude = ops::mean_solar_longitude(julian_century);
         let mean_lunar_longitude = ops::mean_lunar_longitude(julian_century);
@@ -267,7 +267,7 @@ mod tests {
         let utc = local.with_timezone(&Utc);
         let julian_day = ops::julian_day_ymdh(1992, 10, 13, 0.0);
 
-        assert_eq!(ops::julian_day(&utc), julian_day);
+        assert_eq!(ops::julian_day(utc.date()), julian_day);
     }
 
     #[test]

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -5,12 +5,15 @@
 //
 
 use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 use crate::astronomy::ops;
 use crate::astronomy::unit::Stride;
 use crate::astronomy::unit::{Angle, Coordinates};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SolarCoordinates {
     // The declination of the sun, the angle between
     // the rays of the Sun and the plane of the Earth's equator.
@@ -81,6 +84,7 @@ impl SolarCoordinates {
 
 // Solar Time
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SolarTime {
     date: DateTime<Utc>,
     observer: Coordinates,

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -4,14 +4,14 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
-use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+use chrono::{Date, DateTime, Datelike, TimeZone, Utc};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::astronomy::ops;
-use crate::astronomy::unit::Stride;
+//use crate::astronomy::unit::Stride;
 use crate::astronomy::unit::{Angle, Coordinates};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
@@ -31,7 +31,8 @@ pub struct SolarCoordinates {
 }
 
 impl SolarCoordinates {
-    fn new(julian_day: f64) -> Self {
+    fn new<Tz: TimeZone>(date: Date<Tz>) -> Self {
+        let julian_day = ops::julian_day(&date.and_hms(0, 0, 0));
         let julian_century = ops::julian_century(julian_day);
         let mean_solar_longitude = ops::mean_solar_longitude(julian_century);
         let mean_lunar_longitude = ops::mean_lunar_longitude(julian_century);
@@ -78,9 +79,9 @@ impl SolarCoordinates {
         );
 
         SolarCoordinates {
-            declination: declination,
-            right_ascension: right_ascension,
-            apparent_sidereal_time: apparent_sidereal_time,
+            declination,
+            right_ascension,
+            apparent_sidereal_time,
         }
     }
 }
@@ -90,7 +91,7 @@ impl SolarCoordinates {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SolarTime {
-    date: DateTime<Utc>,
+    date: Date<Utc>,
     observer: Coordinates,
     solar: SolarCoordinates,
     pub transit: DateTime<Utc>,
@@ -102,16 +103,14 @@ pub struct SolarTime {
 }
 
 impl SolarTime {
-    pub fn new(date: DateTime<Utc>, coordinates: Coordinates) -> SolarTime {
+    pub fn new(date: Date<Utc>, coordinates: Coordinates) -> SolarTime {
         // All calculation need to occur at 0h0m UTC
-        let today = Utc
-            .ymd(date.year(), date.month(), date.day())
-            .and_hms(0, 0, 0);
-        let tomorrow = today.tomorrow();
-        let yesterday = today.yesterday();
-        let prev_solar = SolarCoordinates::new(yesterday.julian_day());
-        let solar = SolarCoordinates::new(today.julian_day());
-        let next_solar = SolarCoordinates::new(tomorrow.julian_day());
+        let today = Utc.ymd(date.year(), date.month(), date.day());
+        let tomorrow = today.succ();
+        let yesterday = today.pred();
+        let prev_solar = SolarCoordinates::new(yesterday);
+        let solar = SolarCoordinates::new(today);
+        let next_solar = SolarCoordinates::new(tomorrow);
         let solar_altitude = Angle::new(-50.0 / 60.0);
         let approx_transit = ops::approximate_transit(
             coordinates.longitude_angle(),
@@ -154,15 +153,15 @@ impl SolarTime {
         );
 
         SolarTime {
-            date: date,
+            date,
             observer: coordinates,
-            solar: solar,
+            solar,
             transit: SolarTime::setting_hour(transit_time, &date).unwrap(),
             sunrise: SolarTime::setting_hour(sunrise_time, &date).unwrap(),
             sunset: SolarTime::setting_hour(sunset_time, &date).unwrap(),
-            prev_solar: prev_solar,
-            next_solar: next_solar,
-            approx_transit: approx_transit,
+            prev_solar,
+            next_solar,
+            approx_transit,
         }
     }
 
@@ -193,7 +192,7 @@ impl SolarTime {
         self.time_for_solar_angle(angle, true)
     }
 
-    fn setting_hour(value: f64, date: &DateTime<Utc>) -> Option<DateTime<Utc>> {
+    fn setting_hour(value: f64, date: &Date<Utc>) -> Option<DateTime<Utc>> {
         if value.is_normal() {
             let calculated_hours = value.floor();
             let calculated_minutes = ((value - calculated_hours) * 60.0).floor();
@@ -204,22 +203,18 @@ impl SolarTime {
             // wrapping around as needed; otherwise
             // chrono method will panic.
             let (adjusted_hour, adjusted_date) = if calculated_hours < 0.0 {
-                ((calculated_hours + 24.0) as u32, date.yesterday())
+                ((calculated_hours + 24.0) as u32, date.pred())
             } else if calculated_hours >= 24.0 {
-                ((calculated_hours - 24.0) as u32, date.tomorrow())
+                ((calculated_hours - 24.0) as u32, date.succ())
             } else {
-                (calculated_hours as u32, date.clone())
+                (calculated_hours as u32, *date)
             };
 
             // Round to the nearest minute
             let adjusted_mins = (calculated_minutes + calculated_seconds / 60.0).round() as u32;
             let adjusted_secs: u32 = 0;
 
-            Some(
-                adjusted_date
-                    .date()
-                    .and_hms(adjusted_hour, adjusted_mins, adjusted_secs),
-            )
+            Some(adjusted_date.and_hms(adjusted_hour, adjusted_mins, adjusted_secs))
         } else {
             None
         }
@@ -227,19 +222,22 @@ impl SolarTime {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
     use crate::astronomy::ops;
-    use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+    use chrono::{Datelike, Local, TimeZone, Utc};
 
     #[test]
     fn solar_coordinates() {
-        let julian_day = ops::julian_day(1992, 10, 13, 0.0);
-        let solar = SolarCoordinates::new(julian_day);
+        let solar = SolarCoordinates::new(Utc.ymd(1992, 10, 13));
 
         assert_eq!(solar.declination.degrees, -7.7850685152648795);
-        assert_eq!(solar.right_ascension.degrees, 198.38082214251881);
-        assert_eq!(solar.right_ascension.unwound().degrees, 198.38082214251881);
+        assert_eq!(solar.right_ascension.degrees, 198.380_822_142_518_8);
+        assert_eq!(
+            solar.right_ascension.unwound().degrees,
+            198.380_822_142_518_8
+        );
     }
 
     #[test]
@@ -255,8 +253,8 @@ mod tests {
 
     #[test]
     fn calculate_date_for_tomorrow() {
-        let date = Local.ymd(2019, 1, 10).and_hms(0, 0, 0);
-        let tomorrow = date.tomorrow();
+        let date = Local.ymd(2019, 1, 10);
+        let tomorrow = date.succ();
 
         assert_eq!(tomorrow.year(), 2019);
         assert_eq!(tomorrow.month(), 1);
@@ -267,19 +265,19 @@ mod tests {
     fn calculate_julian_date() {
         let local = Utc.ymd(1992, 10, 13).and_hms(0, 0, 0);
         let utc = local.with_timezone(&Utc);
-        let julian_day = ops::julian_day(1992, 10, 13, 0.0);
+        let julian_day = ops::julian_day_ymdh(1992, 10, 13, 0.0);
 
-        assert_eq!(utc.julian_day(), julian_day);
+        assert_eq!(ops::julian_day(&utc), julian_day);
     }
 
     #[test]
     fn calculate_solar_time() {
         let coordinates = Coordinates::new(35.0 + 47.0 / 60.0, -78.0 - 39.0 / 60.0);
-        let date = Utc.ymd(2015, 7, 12).and_hms(0, 0, 0);
+        let date = Utc.ymd(2015, 7, 12);
         let solar = SolarTime::new(date, coordinates);
-        let transit_date = Utc.ymd(2015, 07, 12).and_hms(17, 20, 0);
-        let sunrise_date = Utc.ymd(2015, 07, 12).and_hms(10, 08, 0);
-        let sunset_date = Utc.ymd(2015, 07, 13).and_hms(00, 32, 0);
+        let transit_date = Utc.ymd(2015, 7, 12).and_hms(17, 20, 0);
+        let sunrise_date = Utc.ymd(2015, 7, 12).and_hms(10, 8, 0);
+        let sunset_date = Utc.ymd(2015, 7, 13).and_hms(0, 32, 0);
 
         assert_eq!(solar.transit, transit_date);
         assert_eq!(solar.sunrise, sunrise_date);
@@ -289,7 +287,7 @@ mod tests {
     #[test]
     fn calculate_time_for_solar_angle() {
         let coordinates = Coordinates::new(35.0 + 47.0 / 60.0, -78.0 - 39.0 / 60.0);
-        let date = Utc.ymd(2015, 7, 12).and_hms(0, 0, 0);
+        let date = Utc.ymd(2015, 7, 12);
         let solar = SolarTime::new(date, coordinates);
         let angle = Angle::new(-6.0);
         let twilight_start = solar.time_for_solar_angle(angle, false);
@@ -303,21 +301,19 @@ mod tests {
     fn calculate_corrected_hour_angle() {
         let coordinates = Coordinates::new(35.0 + 47.0 / 60.0, -78.0 - 39.0 / 60.0);
         let date = Utc.ymd(2015, 7, 12).and_hms(0, 0, 0);
-        let today = Utc
-            .ymd(date.year(), date.month(), date.day())
-            .and_hms(0, 0, 0);
-        let tomorrow = today.tomorrow();
-        let yesterday = today.yesterday();
-        let prev_solar = SolarCoordinates::new(yesterday.julian_day());
-        let solar = SolarCoordinates::new(today.julian_day());
-        let next_solar = SolarCoordinates::new(tomorrow.julian_day());
+        let today = Utc.ymd(date.year(), date.month(), date.day());
+        let tomorrow = today.succ();
+        let yesterday = today.pred();
+        let prev_solar = SolarCoordinates::new(yesterday);
+        let solar = SolarCoordinates::new(today);
+        let next_solar = SolarCoordinates::new(tomorrow);
         let solar_altitude = Angle::new(-50.0 / 60.0);
         let approx_transit = ops::approximate_transit(
             coordinates.longitude_angle(),
             solar.apparent_sidereal_time,
             solar.right_ascension,
         );
-        let transit_time = ops::corrected_transit(
+        let _transit_time = ops::corrected_transit(
             approx_transit,
             coordinates.longitude_angle(),
             solar.apparent_sidereal_time,
@@ -339,6 +335,6 @@ mod tests {
             next_solar.declination,
         );
 
-        assert_eq!(sunrise_time, 10.131800480632849);
+        assert_eq!(sunrise_time, 10.131_800_480_632_85);
     }
 }

--- a/src/astronomy/solar.rs
+++ b/src/astronomy/solar.rs
@@ -190,8 +190,6 @@ impl SolarTime {
     }
 
     fn setting_hour(value: f64, date: &DateTime<Utc>) -> Option<DateTime<Utc>> {
-        let mut adjusted_time: Option<DateTime<Utc>> = None;
-
         if value.is_normal() {
             let calculated_hours = value.floor();
             let calculated_minutes = ((value - calculated_hours) * 60.0).floor();
@@ -201,7 +199,9 @@ impl SolarTime {
             // Adjust the hour to be within 0..=23,
             // wrapping around as needed; otherwise
             // chrono method will panic.
-            let (adjusted_hour, adjusted_date) = if calculated_hours >= 24.0 {
+            let (adjusted_hour, adjusted_date) = if calculated_hours <= 0.0 {
+                ((calculated_hours + 24.0) as u32, date.yesterday())
+            } else if calculated_hours >= 24.0 {
                 ((calculated_hours - 24.0) as u32, date.tomorrow())
             } else {
                 (calculated_hours as u32, date.clone())
@@ -211,20 +211,10 @@ impl SolarTime {
             let adjusted_mins = (calculated_minutes + calculated_seconds / 60.0).round() as u32;
             let adjusted_secs: u32 = 0;
 
-            let adjusted = Utc
-                .ymd(
-                    adjusted_date.year(),
-                    adjusted_date.month(),
-                    adjusted_date.day(),
-                )
-                .and_hms(adjusted_hour, adjusted_mins, adjusted_secs);
-
-            adjusted_time = Some(adjusted);
+            Some(adjusted_date.date().and_hms(adjusted_hour, adjusted_mins, adjusted_secs))
         } else {
-            // Nothing to do.
+            None
         }
-
-        adjusted_time
     }
 }
 

--- a/src/astronomy/unit.rs
+++ b/src/astronomy/unit.rs
@@ -9,8 +9,10 @@ use std::ops::{Add, Div, Mul, Sub};
 
 use crate::astronomy::ops;
 use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub trait Normalize {
     fn normalized_to_scale(&self, max: f64) -> f64;
@@ -101,6 +103,7 @@ impl<Tz: TimeZone> Stride for DateTime<Tz> {
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Angle {
     pub degrees: f64,
 }
@@ -190,6 +193,7 @@ impl Div for Angle {
 /// Both latiude and longitude values are specified in degrees.
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Coordinates {
     pub latitude: f64,
     pub longitude: f64,

--- a/src/astronomy/unit.rs
+++ b/src/astronomy/unit.rs
@@ -141,7 +141,7 @@ impl Coordinates {
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
-    use chrono::{Duration, DurationRound, TimeZone, Utc};
+    use chrono::{Duration, DurationRound, Local, TimeZone};
 
     use super::*;
     use std::f64::consts::PI;
@@ -206,16 +206,16 @@ mod tests {
 
     #[test]
     fn calculate_nearest_minute() {
-        let time_1 = Utc.ymd(2015, 7, 13).and_hms(4, 37, 30);
-        let time_2 = Utc.ymd(2015, 7, 13).and_hms(5, 59, 20);
+        let time_1 = Local.ymd(2015, 7, 13).and_hms(4, 37, 30);
+        let time_2 = Local.ymd(2015, 7, 13).and_hms(5, 59, 20);
 
         assert_eq!(
             time_1.duration_round(Duration::minutes(1)).unwrap(),
-            Utc.ymd(2015, 7, 13).and_hms(4, 38, 0)
+            Local.ymd(2015, 7, 13).and_hms(4, 38, 0)
         );
         assert_eq!(
             time_2.duration_round(Duration::minutes(1)).unwrap(),
-            Utc.ymd(2015, 7, 13).and_hms(5, 59, 0)
+            Local.ymd(2015, 7, 13).and_hms(5, 59, 0)
         );
     }
 }

--- a/src/astronomy/unit.rs
+++ b/src/astronomy/unit.rs
@@ -9,6 +9,8 @@ use std::ops::{Add, Div, Mul, Sub};
 
 use crate::astronomy::ops;
 use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 pub trait Normalize {
     fn normalized_to_scale(&self, max: f64) -> f64;
@@ -98,6 +100,7 @@ impl<Tz: TimeZone> Stride for DateTime<Tz> {
 }
 
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Angle {
     pub degrees: f64,
 }
@@ -186,6 +189,7 @@ impl Div for Angle {
 /// The latitude and longitude associated with a location.
 /// Both latiude and longitude values are specified in degrees.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinates {
     pub latitude: f64,
     pub longitude: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,45 +16,43 @@
 //! let new_york_city = Coordinates::new(40.7128, -74.0059);
 //! let date          = Utc.ymd(2019, 1, 25);
 //! let params        = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
-//! let prayers       = PrayerSchedule::new()
+//! let prayers       = PrayerSchedule::default()
 //!                       .on(date)
 //!                       .for_location(new_york_city)
 //!                       .with_configuration(params)
 //!                       .calculate();
 //! ```
 
-#![deny(future_incompatible)]
+#![deny(nonstandard_style, unused, future_incompatible)]
 
 mod astronomy;
 mod models;
 mod schedule;
 
-pub use crate::astronomy::unit::{Coordinates, Stride};
-pub use crate::models::adjustments::{Adjustment, TimeAdjustment};
-pub use crate::models::high_altitude_rule::HighLatitudeRule;
-pub use crate::models::madhab::Madhab;
-pub use crate::models::method::Method;
-pub use crate::models::parameters::{Configuration, Parameters};
-pub use crate::models::prayer::Prayer;
+pub use crate::astronomy::{qiblah::Qiblah, unit::Coordinates};
+pub use crate::models::{
+    adjustments::{Adjustment, TimeAdjustment},
+    high_altitude_rule::HighLatitudeRule,
+    madhab::Madhab,
+    method::Method,
+    parameters::{Configuration, Parameters},
+    prayer::Prayer,
+};
 pub use crate::schedule::{PrayerSchedule, PrayerTimes};
 pub use chrono::{Date, DateTime, Datelike, Duration, Local, TimeZone, Timelike, Utc};
 
 /// A convenience module appropriate for glob imports (`use salah::prelude::*;`).
 pub mod prelude {
     #[doc(no_inline)]
-    pub use crate::astronomy::unit::{Coordinates, Stride};
+    pub use crate::astronomy::unit::Coordinates;
     #[doc(no_inline)]
-    pub use crate::models::adjustments::{Adjustment, TimeAdjustment};
-    #[doc(no_inline)]
-    pub use crate::models::high_altitude_rule::HighLatitudeRule;
-    #[doc(no_inline)]
-    pub use crate::models::madhab::Madhab;
-    #[doc(no_inline)]
-    pub use crate::models::method::Method;
-    #[doc(no_inline)]
-    pub use crate::models::parameters::{Configuration, Parameters};
-    #[doc(no_inline)]
-    pub use crate::models::prayer::Prayer;
+    pub use crate::models::{
+        high_altitude_rule::HighLatitudeRule,
+        madhab::Madhab,
+        method::Method,
+        parameters::{Configuration, Parameters},
+        prayer::Prayer,
+    };
     #[doc(no_inline)]
     pub use crate::schedule::{PrayerSchedule, PrayerTimes};
     #[doc(no_inline)]
@@ -109,7 +107,7 @@ mod tests {
         let date = Utc.ymd(2015, 7, 12);
         let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
-        let result = PrayerSchedule::new()
+        let result = PrayerSchedule::default()
             .on(date)
             .for_location(coordinates)
             .with_configuration(params)
@@ -149,7 +147,7 @@ mod tests {
                 );
             }
 
-            Err(_err) => assert!(false),
+            Err(_err) => panic!(),
         }
     }
 
@@ -157,7 +155,7 @@ mod tests {
     fn calculate_times_using_the_builder_failure() {
         let date = Utc.ymd(2015, 7, 12);
         let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
-        let result = PrayerSchedule::new()
+        let result = PrayerSchedule::default()
             .on(date)
             .with_configuration(params)
             .calculate();
@@ -174,7 +172,7 @@ mod tests {
         // let qiyam_date  = Utc.ymd(2015, 7, 13);
         let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
-        let result = PrayerSchedule::new()
+        let result = PrayerSchedule::default()
             .on(date)
             .for_location(coordinates)
             .with_configuration(params)
@@ -198,7 +196,7 @@ mod tests {
                     "5:59 AM"
                 );
             }
-            Err(_err) => assert!(false),
+            Err(_err) => panic!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod schedule;
 
 pub use crate::astronomy::unit::{Coordinates, Stride};
 pub use crate::models::adjustments::{Adjustment, TimeAdjustment};
+pub use crate::models::high_altitude_rule::HighLatitudeRule;
 pub use crate::models::madhab::Madhab;
 pub use crate::models::method::Method;
 pub use crate::models::parameters::{Configuration, Parameters};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //!                       .calculate();
 //! ```
 
+#![deny(future_incompatible)]
+
 mod astronomy;
 mod models;
 mod schedule;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use crate::models::adjustments::{Adjustment, TimeAdjustment};
     #[doc(no_inline)]
+    pub use crate::models::high_altitude_rule::HighLatitudeRule;
+    #[doc(no_inline)]
     pub use crate::models::madhab::Madhab;
     #[doc(no_inline)]
     pub use crate::models::method::Method;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! let new_york_city = Coordinates::new(40.7128, -74.0059);
 //! let date          = Utc.ymd(2019, 1, 25);
-//! let params        = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+//! let params        = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
 //! let prayers       = PrayerSchedule::default()
 //!                       .on(date)
 //!                       .for_location(new_york_city)
@@ -31,12 +31,8 @@ mod schedule;
 
 pub use crate::astronomy::{qiblah::Qiblah, unit::Coordinates};
 pub use crate::models::{
-    adjustments::{Adjustment, TimeAdjustment},
-    high_altitude_rule::HighLatitudeRule,
-    madhab::Madhab,
-    method::Method,
-    parameters::{Configuration, Parameters},
-    prayer::Prayer,
+    adjustments::TimeAdjustments, high_altitude_rule::HighLatitudeRule, madhab::Madhab,
+    method::Method, parameters::Parameters, prayer::Prayer,
 };
 pub use crate::schedule::{PrayerSchedule, PrayerTimes};
 pub use chrono::{Date, DateTime, Datelike, Duration, Local, TimeZone, Timelike, Utc};
@@ -47,11 +43,8 @@ pub mod prelude {
     pub use crate::astronomy::unit::Coordinates;
     #[doc(no_inline)]
     pub use crate::models::{
-        high_altitude_rule::HighLatitudeRule,
-        madhab::Madhab,
-        method::Method,
-        parameters::{Configuration, Parameters},
-        prayer::Prayer,
+        high_altitude_rule::HighLatitudeRule, madhab::Madhab, method::Method,
+        parameters::Parameters, prayer::Prayer,
     };
     #[doc(no_inline)]
     pub use crate::schedule::{PrayerSchedule, PrayerTimes};
@@ -66,7 +59,7 @@ mod tests {
     #[test]
     fn calculate_prayer_times() {
         let local_date = Utc.ymd(2015, 7, 12);
-        let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
         let schedule = PrayerTimes::new(local_date, coordinates, params);
 
@@ -105,7 +98,7 @@ mod tests {
     #[test]
     fn calculate_times_using_the_builder_successfully() {
         let date = Utc.ymd(2015, 7, 12);
-        let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
         let result = PrayerSchedule::default()
             .on(date)
@@ -154,7 +147,7 @@ mod tests {
     #[test]
     fn calculate_times_using_the_builder_failure() {
         let date = Utc.ymd(2015, 7, 12);
-        let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let result = PrayerSchedule::default()
             .on(date)
             .with_configuration(params)
@@ -170,7 +163,7 @@ mod tests {
     fn calculate_qiyam_times() {
         let date = Utc.ymd(2015, 7, 12);
         // let qiyam_date  = Utc.ymd(2015, 7, 13);
-        let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
         let result = PrayerSchedule::default()
             .on(date)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,9 @@
 //! use salah::prelude::*;
 //!
 //! let new_york_city = Coordinates::new(40.7128, -74.0059);
-//! let date          = Utc.ymd(2019, 1, 25);
+//! let date          = Local.ymd(2019, 1, 25);
 //! let params        = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
-//! let prayers       = PrayerSchedule::default()
-//!                       .on(date)
-//!                       .for_location(new_york_city)
-//!                       .with_configuration(params)
-//!                       .calculate();
+//! let prayers       = PrayerTimes::calculate(date, new_york_city, params);
 //! ```
 
 #![deny(nonstandard_style, unused, future_incompatible)]
@@ -34,7 +30,7 @@ pub use crate::models::{
     adjustments::TimeAdjustments, high_altitude_rule::HighLatitudeRule, madhab::Madhab,
     method::Method, parameters::Parameters, prayer::Prayer,
 };
-pub use crate::schedule::{PrayerSchedule, PrayerTimes};
+pub use crate::schedule::PrayerTimes;
 pub use chrono::{Date, DateTime, Datelike, Duration, Local, TimeZone, Timelike, Utc};
 
 /// A convenience module appropriate for glob imports (`use salah::prelude::*;`).
@@ -47,7 +43,7 @@ pub mod prelude {
         parameters::Parameters, prayer::Prayer,
     };
     #[doc(no_inline)]
-    pub use crate::schedule::{PrayerSchedule, PrayerTimes};
+    pub use crate::schedule::PrayerTimes;
     #[doc(no_inline)]
     pub use chrono::{Date, DateTime, Datelike, Duration, Local, TimeZone, Timelike, Utc};
 }
@@ -58,138 +54,88 @@ mod tests {
 
     #[test]
     fn calculate_prayer_times() {
-        let local_date = Utc.ymd(2015, 7, 12);
+        let local_date = Local.ymd(2015, 7, 12);
         let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
-        let schedule = PrayerTimes::new(local_date, coordinates, params);
+        let schedule = PrayerTimes::calculate(local_date, coordinates, params);
 
         assert_eq!(
-            schedule.time(Prayer::Fajr).format("%-l:%M %p").to_string(),
+            schedule
+                .time(Prayer::Fajr)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
             "8:42 AM"
         );
         assert_eq!(
             schedule
                 .time(Prayer::Sunrise)
+                .with_timezone(&Utc)
                 .format("%-l:%M %p")
                 .to_string(),
             "10:08 AM"
         );
         assert_eq!(
-            schedule.time(Prayer::Dhuhr).format("%-l:%M %p").to_string(),
+            schedule
+                .time(Prayer::Dhuhr)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
             "5:21 PM"
         );
         assert_eq!(
-            schedule.time(Prayer::Asr).format("%-l:%M %p").to_string(),
+            schedule
+                .time(Prayer::Asr)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
             "10:22 PM"
         );
         assert_eq!(
             schedule
                 .time(Prayer::Maghrib)
+                .with_timezone(&Utc)
                 .format("%-l:%M %p")
                 .to_string(),
             "12:32 AM"
         );
         assert_eq!(
-            schedule.time(Prayer::Isha).format("%-l:%M %p").to_string(),
+            schedule
+                .time(Prayer::Isha)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
             "1:57 AM"
         );
     }
 
     #[test]
-    fn calculate_times_using_the_builder_successfully() {
-        let date = Utc.ymd(2015, 7, 12);
-        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
-        let coordinates = Coordinates::new(35.7750, -78.6336);
-        let result = PrayerSchedule::default()
-            .on(date)
-            .for_location(coordinates)
-            .with_configuration(params)
-            .calculate();
-
-        match result {
-            Ok(schedule) => {
-                assert_eq!(
-                    schedule.time(Prayer::Fajr).format("%-l:%M %p").to_string(),
-                    "8:42 AM"
-                );
-                assert_eq!(
-                    schedule
-                        .time(Prayer::Sunrise)
-                        .format("%-l:%M %p")
-                        .to_string(),
-                    "10:08 AM"
-                );
-                assert_eq!(
-                    schedule.time(Prayer::Dhuhr).format("%-l:%M %p").to_string(),
-                    "5:21 PM"
-                );
-                assert_eq!(
-                    schedule.time(Prayer::Asr).format("%-l:%M %p").to_string(),
-                    "10:22 PM"
-                );
-                assert_eq!(
-                    schedule
-                        .time(Prayer::Maghrib)
-                        .format("%-l:%M %p")
-                        .to_string(),
-                    "12:32 AM"
-                );
-                assert_eq!(
-                    schedule.time(Prayer::Isha).format("%-l:%M %p").to_string(),
-                    "1:57 AM"
-                );
-            }
-
-            Err(_err) => panic!(),
-        }
-    }
-
-    #[test]
-    fn calculate_times_using_the_builder_failure() {
-        let date = Utc.ymd(2015, 7, 12);
-        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
-        let result = PrayerSchedule::default()
-            .on(date)
-            .with_configuration(params)
-            .calculate();
-
-        assert!(
-            result.is_err(),
-            "We were expecting an error, but received data."
-        );
-    }
-
-    #[test]
     fn calculate_qiyam_times() {
-        let date = Utc.ymd(2015, 7, 12);
-        // let qiyam_date  = Utc.ymd(2015, 7, 13);
+        let date = Local.ymd(2015, 7, 12);
+        // let qiyam_date  = Local.ymd(2015, 7, 13);
         let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
         let coordinates = Coordinates::new(35.7750, -78.6336);
-        let result = PrayerSchedule::default()
-            .on(date)
-            .for_location(coordinates)
-            .with_configuration(params)
-            .calculate();
+        let schedule = PrayerTimes::calculate(date, coordinates, params);
 
-        match result {
-            Ok(schedule) => {
-                // Today's Maghrib: 2015-07-13T00:32:00Z
-                // Tomorrow's Fajr: 2015-07-13T08:43:00Z
-                // Middle of Night: 2015-07-13T04:38:00Z
-                // Last Third     : 2015-07-13T05:59:00Z
-                assert_eq!(
-                    schedule
-                        .time(Prayer::Maghrib)
-                        .format("%-l:%M %p")
-                        .to_string(),
-                    "12:32 AM"
-                );
-                assert_eq!(
-                    schedule.time(Prayer::Qiyam).format("%-l:%M %p").to_string(),
-                    "5:59 AM"
-                );
-            }
-            Err(_err) => panic!(),
-        }
+        // Today's Maghrib: 2015-07-13T00:32:00Z
+        // Tomorrow's Fajr: 2015-07-13T08:43:00Z
+        // Middle of Night: 2015-07-13T04:38:00Z
+        // Last Third     : 2015-07-13T05:59:00Z
+        assert_eq!(
+            schedule
+                .time(Prayer::Maghrib)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
+            "12:32 AM"
+        );
+        assert_eq!(
+            schedule
+                .time(Prayer::Qiyam)
+                .with_timezone(&Utc)
+                .format("%-l:%M %p")
+                .to_string(),
+            "5:59 AM"
+        );
     }
 }

--- a/src/models/adjustments.rs
+++ b/src/models/adjustments.rs
@@ -14,6 +14,7 @@ use std::default::Default;
 /// Time adjustment for all prayer times.
 /// The value is specified in *minutes* and
 /// can be either positive or negative.
+
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -29,12 +30,12 @@ pub struct TimeAdjustment {
 impl TimeAdjustment {
     pub fn new(fajr: i64, sunrise: i64, dhuhr: i64, asr: i64, maghrib: i64, isha: i64) -> Self {
         TimeAdjustment {
-            fajr: fajr,
-            sunrise: sunrise,
-            dhuhr: dhuhr,
-            asr: asr,
-            maghrib: maghrib,
-            isha: isha,
+            fajr,
+            sunrise,
+            dhuhr,
+            asr,
+            maghrib,
+            isha,
         }
     }
 }
@@ -54,6 +55,7 @@ impl Default for TimeAdjustment {
 
 /// Builder struct for the [TimeAdjustment](struct.TimeAdjustment.html).
 /// It is recommended to use this for all needed adjustments.
+#[derive(Default)]
 pub struct Adjustment {
     fajr: i64,
     sunrise: i64,
@@ -64,43 +66,32 @@ pub struct Adjustment {
 }
 
 impl Adjustment {
-    pub fn new() -> Adjustment {
-        Adjustment {
-            fajr: 0,
-            sunrise: 0,
-            dhuhr: 0,
-            asr: 0,
-            maghrib: 0,
-            isha: 0,
-        }
-    }
-
-    pub fn fajr<'a>(&'a mut self, fajr: i64) -> &'a mut Adjustment {
+    pub fn fajr(&mut self, fajr: i64) -> &mut Adjustment {
         self.fajr = fajr;
         self
     }
 
-    pub fn sunrise<'a>(&'a mut self, sunrise: i64) -> &'a mut Adjustment {
+    pub fn sunrise(&mut self, sunrise: i64) -> &mut Adjustment {
         self.sunrise = sunrise;
         self
     }
 
-    pub fn dhuhr<'a>(&'a mut self, dhuhr: i64) -> &'a mut Adjustment {
+    pub fn dhuhr(&mut self, dhuhr: i64) -> &mut Adjustment {
         self.dhuhr = dhuhr;
         self
     }
 
-    pub fn asr<'a>(&'a mut self, asr: i64) -> &'a mut Adjustment {
+    pub fn asr(&mut self, asr: i64) -> &mut Adjustment {
         self.asr = asr;
         self
     }
 
-    pub fn maghrib<'a>(&'a mut self, maghrib: i64) -> &'a mut Adjustment {
+    pub fn maghrib(&mut self, maghrib: i64) -> &mut Adjustment {
         self.maghrib = maghrib;
         self
     }
 
-    pub fn isha<'a>(&'a mut self, isha: i64) -> &'a mut Adjustment {
+    pub fn isha(&mut self, isha: i64) -> &mut Adjustment {
         self.isha = isha;
         self
     }

--- a/src/models/adjustments.rs
+++ b/src/models/adjustments.rs
@@ -4,8 +4,10 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use std::default::Default;
 
@@ -14,6 +16,7 @@ use std::default::Default;
 /// can be either positive or negative.
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct TimeAdjustment {
     pub fajr: i64,
     pub sunrise: i64,

--- a/src/models/adjustments.rs
+++ b/src/models/adjustments.rs
@@ -4,12 +4,16 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 use std::default::Default;
 
 /// Time adjustment for all prayer times.
 /// The value is specified in *minutes* and
 /// can be either positive or negative.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TimeAdjustment {
     pub fajr: i64,
     pub sunrise: i64,

--- a/src/models/adjustments.rs
+++ b/src/models/adjustments.rs
@@ -15,10 +15,10 @@ use std::default::Default;
 /// The value is specified in *minutes* and
 /// can be either positive or negative.
 
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(Default, PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct TimeAdjustment {
+pub struct TimeAdjustments {
     pub fajr: i64,
     pub sunrise: i64,
     pub dhuhr: i64,
@@ -27,83 +27,15 @@ pub struct TimeAdjustment {
     pub isha: i64,
 }
 
-impl TimeAdjustment {
+impl TimeAdjustments {
     pub fn new(fajr: i64, sunrise: i64, dhuhr: i64, asr: i64, maghrib: i64, isha: i64) -> Self {
-        TimeAdjustment {
+        TimeAdjustments {
             fajr,
             sunrise,
             dhuhr,
             asr,
             maghrib,
             isha,
-        }
-    }
-}
-
-impl Default for TimeAdjustment {
-    fn default() -> TimeAdjustment {
-        TimeAdjustment {
-            fajr: 0,
-            sunrise: 0,
-            dhuhr: 0,
-            asr: 0,
-            maghrib: 0,
-            isha: 0,
-        }
-    }
-}
-
-/// Builder struct for the [TimeAdjustment](struct.TimeAdjustment.html).
-/// It is recommended to use this for all needed adjustments.
-#[derive(Default)]
-pub struct Adjustment {
-    fajr: i64,
-    sunrise: i64,
-    dhuhr: i64,
-    asr: i64,
-    maghrib: i64,
-    isha: i64,
-}
-
-impl Adjustment {
-    pub fn fajr(&mut self, fajr: i64) -> &mut Adjustment {
-        self.fajr = fajr;
-        self
-    }
-
-    pub fn sunrise(&mut self, sunrise: i64) -> &mut Adjustment {
-        self.sunrise = sunrise;
-        self
-    }
-
-    pub fn dhuhr(&mut self, dhuhr: i64) -> &mut Adjustment {
-        self.dhuhr = dhuhr;
-        self
-    }
-
-    pub fn asr(&mut self, asr: i64) -> &mut Adjustment {
-        self.asr = asr;
-        self
-    }
-
-    pub fn maghrib(&mut self, maghrib: i64) -> &mut Adjustment {
-        self.maghrib = maghrib;
-        self
-    }
-
-    pub fn isha(&mut self, isha: i64) -> &mut Adjustment {
-        self.isha = isha;
-        self
-    }
-
-    pub fn done(&self) -> TimeAdjustment {
-        TimeAdjustment {
-            fajr: self.fajr,
-            sunrise: self.sunrise,
-            dhuhr: self.dhuhr,
-            asr: self.asr,
-            maghrib: self.maghrib,
-            isha: self.isha,
         }
     }
 }

--- a/src/models/high_altitude_rule.rs
+++ b/src/models/high_altitude_rule.rs
@@ -4,8 +4,12 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// Rule for approximating Fajr and Isha at high latitudes
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HighLatitudeRule {
     MiddleOfTheNight,
     SeventhOfTheNight,

--- a/src/models/high_altitude_rule.rs
+++ b/src/models/high_altitude_rule.rs
@@ -8,7 +8,7 @@
 use serde::{Serialize, Deserialize};
 
 /// Rule for approximating Fajr and Isha at high latitudes
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum HighLatitudeRule {
     MiddleOfTheNight,

--- a/src/models/high_altitude_rule.rs
+++ b/src/models/high_altitude_rule.rs
@@ -4,12 +4,15 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Rule for approximating Fajr and Isha at high latitudes
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum HighLatitudeRule {
     MiddleOfTheNight,
     SeventhOfTheNight,

--- a/src/models/high_altitude_rule.rs
+++ b/src/models/high_altitude_rule.rs
@@ -10,10 +10,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Rule for approximating Fajr and Isha at high latitudes
+
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum HighLatitudeRule {
+    // FIXME: docs
     MiddleOfTheNight,
     SeventhOfTheNight,
     TwilightAngle,

--- a/src/models/madhab.rs
+++ b/src/models/madhab.rs
@@ -4,10 +4,14 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// Setting for the Asr prayer time. 
 /// For Hanafi madhab, the Asr is bit later 
 /// than that of the Shafi madhab.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Madhab {
     Shafi = 1,
     Hanafi = 2,

--- a/src/models/madhab.rs
+++ b/src/models/madhab.rs
@@ -10,7 +10,7 @@ use serde::{Serialize, Deserialize};
 /// Setting for the Asr prayer time. 
 /// For Hanafi madhab, the Asr is bit later 
 /// than that of the Shafi madhab.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Madhab {
     Shafi = 1,

--- a/src/models/madhab.rs
+++ b/src/models/madhab.rs
@@ -4,14 +4,17 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-/// Setting for the Asr prayer time. 
-/// For Hanafi madhab, the Asr is bit later 
+/// Setting for the Asr prayer time.
+/// For Hanafi madhab, the Asr is bit later
 /// than that of the Shafi madhab.
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Madhab {
     Shafi = 1,
     Hanafi = 2,

--- a/src/models/madhab.rs
+++ b/src/models/madhab.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Setting for the Asr prayer time.
 /// For Hanafi madhab, the Asr is bit later
 /// than that of the Shafi madhab.
+
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -21,12 +22,14 @@ pub enum Madhab {
 }
 
 impl Madhab {
-    pub fn shadow(&self) -> i32 {
-        *self as i32
+    /// Shadow length
+    pub fn shadow(&self) -> f64 {
+        *self as i32 as f64
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 
@@ -34,13 +37,13 @@ mod tests {
     fn shafi_shadow() {
         let shafi = Madhab::Shafi;
 
-        assert_eq!(shafi.shadow(), 1);
+        assert_eq!(shafi.shadow(), 1.);
     }
 
     #[test]
     fn hanafi_shadow() {
         let hanafi = Madhab::Hanafi;
 
-        assert_eq!(hanafi.shadow(), 2);
+        assert_eq!(hanafi.shadow(), 2.);
     }
 }

--- a/src/models/method.rs
+++ b/src/models/method.rs
@@ -9,14 +9,11 @@ use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{
-    adjustments::Adjustment,
-    parameters::{Configuration, Parameters},
-};
+use super::{adjustments::TimeAdjustments, parameters::Parameters};
 
 /// Provides preset configuration for a few authorities
 /// for calculating prayer times.
-#[derive(PartialEq, Debug, Copy, Clone, Hash)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Method {
@@ -56,62 +53,111 @@ pub enum Method {
 
 impl Method {
     /// Get method parameters
-    pub fn parameters(&self) -> Parameters {
+    pub fn parameters(self) -> Parameters {
         match self {
-            Method::MuslimWorldLeague => Configuration::new(18.0, 17.0)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(1).done())
-                .done(),
+            Method::MuslimWorldLeague => Parameters {
+                fajr_angle: 18.,
+                isha_angle: 17.,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::Egyptian => Configuration::new(19.5, 17.5)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(1).done())
-                .done(),
+            Method::Egyptian => Parameters {
+                fajr_angle: 19.5,
+                isha_angle: 17.5,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::Karachi => Configuration::new(18.0, 18.0)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(1).done())
-                .done(),
+            Method::Karachi => Parameters {
+                fajr_angle: 18.,
+                isha_angle: 18.,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::UmmAlQura => Configuration::new(18.5, 0.0)
-                .method(*self)
-                .isha_interval(90)
-                .done(),
-            Method::Dubai => Configuration::new(18.2, 18.2)
-                .method(*self)
-                .method_adjustments(
-                    Adjustment::default()
-                        .sunrise(-3)
-                        .dhuhr(3)
-                        .asr(3)
-                        .maghrib(3)
-                        .done(),
-                )
-                .done(),
+            Method::UmmAlQura => Parameters {
+                fajr_angle: 18.5,
+                isha_interval: 90,
+                method: self,
+                ..Default::default()
+            },
 
-            Method::MoonsightingCommittee => Configuration::new(18.0, 18.0)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(5).maghrib(3).done())
-                .done(),
+            Method::Dubai => Parameters {
+                fajr_angle: 18.2,
+                isha_angle: 18.2,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    sunrise: -3,
+                    dhuhr: 3,
+                    asr: 3,
+                    maghrib: 3,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::NorthAmerica => Configuration::new(15.0, 15.0)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(1).done())
-                .done(),
+            Method::MoonsightingCommittee => Parameters {
+                fajr_angle: 18.,
+                isha_angle: 18.,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 5,
+                    maghrib: 3,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::Kuwait => Configuration::new(18.0, 17.5).method(*self).done(),
+            Method::NorthAmerica => Parameters {
+                fajr_angle: 15.,
+                isha_angle: 15.,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
 
-            Method::Qatar => Configuration::new(18.0, 0.0)
-                .method(*self)
-                .isha_interval(90)
-                .done(),
+            Method::Kuwait => Parameters {
+                fajr_angle: 18.,
+                isha_angle: 17.5,
+                method: self,
+                ..Default::default()
+            },
 
-            Method::Singapore => Configuration::new(20.0, 18.0)
-                .method(*self)
-                .method_adjustments(Adjustment::default().dhuhr(1).done())
-                .done(),
+            Method::Qatar => Parameters {
+                fajr_angle: 18.,
+                isha_interval: 90,
+                method: self,
+                ..Default::default()
+            },
 
-            Method::Other => Configuration::new(0.0, 0.0).method(*self).done(),
+            Method::Singapore => Parameters {
+                fajr_angle: 20.,
+                isha_angle: 18.,
+                method: self,
+                method_adjustments: TimeAdjustments {
+                    dhuhr: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+
+            Method::Other => Parameters::default(),
         }
     }
 }

--- a/src/models/method.rs
+++ b/src/models/method.rs
@@ -4,12 +4,16 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 use super::adjustments::{Adjustment, TimeAdjustment};
 use super::parameters::{Configuration, Parameters};
 
 /// Provides preset configuration for a few authorities
 /// for calculating prayer times.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Method {
     // Muslim World League
     MuslimWorldLeague,

--- a/src/models/method.rs
+++ b/src/models/method.rs
@@ -4,8 +4,10 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::adjustments::{Adjustment, TimeAdjustment};
 use super::parameters::{Configuration, Parameters};
@@ -14,6 +16,7 @@ use super::parameters::{Configuration, Parameters};
 /// for calculating prayer times.
 #[derive(PartialEq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Method {
     // Muslim World League
     MuslimWorldLeague,

--- a/src/models/method.rs
+++ b/src/models/method.rs
@@ -9,8 +9,10 @@ use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::adjustments::{Adjustment, TimeAdjustment};
-use super::parameters::{Configuration, Parameters};
+use super::{
+    adjustments::Adjustment,
+    parameters::{Configuration, Parameters},
+};
 
 /// Provides preset configuration for a few authorities
 /// for calculating prayer times.
@@ -18,56 +20,57 @@ use super::parameters::{Configuration, Parameters};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Method {
-    // Muslim World League
+    /// Muslim World League
     MuslimWorldLeague,
 
-    //Egyptian General Authority of Survey
+    /// Egyptian General Authority of Survey
     Egyptian,
 
-    // University of Islamic Sciences, Karachi
+    /// University of Islamic Sciences, Karachi
     Karachi,
 
-    // Umm al-Qura University, Makkah
+    /// Umm al-Qura University, Makkah
     UmmAlQura,
 
-    // The Gulf Region
+    /// The Gulf Region
     Dubai,
 
-    // Moonsighting Committee
+    /// Moonsighting Committee
     MoonsightingCommittee,
 
-    // ISNA
+    /// ISNA
     NorthAmerica,
 
-    // Kuwait
+    /// Kuwait
     Kuwait,
 
-    // Qatar
+    /// Qatar
     Qatar,
 
-    // Singapore
+    /// Singapore
     Singapore,
 
-    // Other
+    /// Other
     Other,
 }
 
 impl Method {
+    /// Get method parameters
     pub fn parameters(&self) -> Parameters {
         match self {
             Method::MuslimWorldLeague => Configuration::new(18.0, 17.0)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(1).done())
+                .method_adjustments(Adjustment::default().dhuhr(1).done())
                 .done(),
 
             Method::Egyptian => Configuration::new(19.5, 17.5)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(1).done())
+                .method_adjustments(Adjustment::default().dhuhr(1).done())
                 .done(),
 
             Method::Karachi => Configuration::new(18.0, 18.0)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(1).done())
+                .method_adjustments(Adjustment::default().dhuhr(1).done())
                 .done(),
 
             Method::UmmAlQura => Configuration::new(18.5, 0.0)
@@ -77,7 +80,7 @@ impl Method {
             Method::Dubai => Configuration::new(18.2, 18.2)
                 .method(*self)
                 .method_adjustments(
-                    Adjustment::new()
+                    Adjustment::default()
                         .sunrise(-3)
                         .dhuhr(3)
                         .asr(3)
@@ -88,12 +91,12 @@ impl Method {
 
             Method::MoonsightingCommittee => Configuration::new(18.0, 18.0)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(5).maghrib(3).done())
+                .method_adjustments(Adjustment::default().dhuhr(5).maghrib(3).done())
                 .done(),
 
             Method::NorthAmerica => Configuration::new(15.0, 15.0)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(1).done())
+                .method_adjustments(Adjustment::default().dhuhr(1).done())
                 .done(),
 
             Method::Kuwait => Configuration::new(18.0, 17.5).method(*self).done(),
@@ -105,7 +108,7 @@ impl Method {
 
             Method::Singapore => Configuration::new(20.0, 18.0)
                 .method(*self)
-                .method_adjustments(Adjustment::new().dhuhr(1).done())
+                .method_adjustments(Adjustment::default().dhuhr(1).done())
                 .done(),
 
             Method::Other => Configuration::new(0.0, 0.0).method(*self).done(),
@@ -114,6 +117,7 @@ impl Method {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/models/method.rs
+++ b/src/models/method.rs
@@ -12,7 +12,7 @@ use super::parameters::{Configuration, Parameters};
 
 /// Provides preset configuration for a few authorities
 /// for calculating prayer times.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Method {
     // Muslim World League

--- a/src/models/parameters.rs
+++ b/src/models/parameters.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::adjustments::{Adjustment, TimeAdjustment};
+use super::adjustments::TimeAdjustment;
 use super::high_altitude_rule::HighLatitudeRule;
 use super::madhab::Madhab;
 use super::method::Method;
@@ -37,8 +37,8 @@ pub struct Parameters {
 impl Parameters {
     pub fn new(fajr_angle: f64, isha_angle: f64) -> Parameters {
         Parameters {
-            fajr_angle: fajr_angle,
-            isha_angle: isha_angle,
+            fajr_angle,
+            isha_angle,
             method: Method::Other,
             isha_interval: 0,
             madhab: Madhab::Shafi,
@@ -87,8 +87,8 @@ pub struct Configuration {
 impl Configuration {
     pub fn new(fajr_angle: f64, isha_angle: f64) -> Configuration {
         Configuration {
-            fajr_angle: fajr_angle,
-            isha_angle: isha_angle,
+            fajr_angle,
+            isha_angle,
             method: Method::Other,
             isha_interval: 0,
             madhab: Madhab::Shafi,
@@ -105,33 +105,30 @@ impl Configuration {
         params
     }
 
-    pub fn method<'a>(&'a mut self, method: Method) -> &'a mut Configuration {
+    pub fn method(&mut self, method: Method) -> &mut Configuration {
         self.method = method;
         self
     }
 
-    pub fn method_adjustments<'a>(
-        &'a mut self,
-        method_adjustments: TimeAdjustment,
-    ) -> &'a mut Configuration {
+    pub fn method_adjustments(&mut self, method_adjustments: TimeAdjustment) -> &mut Configuration {
         self.method_adjustments = method_adjustments;
         self
     }
 
-    pub fn high_latitude_rule<'a>(
-        &'a mut self,
+    pub fn high_latitude_rule(
+        &mut self,
         high_latitude_rule: HighLatitudeRule,
-    ) -> &'a mut Configuration {
+    ) -> &mut Configuration {
         self.high_latitude_rule = high_latitude_rule;
         self
     }
 
-    pub fn madhab<'a>(&'a mut self, madhab: Madhab) -> &'a mut Configuration {
+    pub fn madhab(&mut self, madhab: Madhab) -> &mut Configuration {
         self.madhab = madhab;
         self
     }
 
-    pub fn isha_interval<'a>(&'a mut self, isha_interval: i32) -> &'a mut Configuration {
+    pub fn isha_interval(&mut self, isha_interval: i32) -> &mut Configuration {
         self.isha_angle = 0.0;
         self.isha_interval = isha_interval;
         self
@@ -152,6 +149,7 @@ impl Configuration {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/models/parameters.rs
+++ b/src/models/parameters.rs
@@ -4,8 +4,10 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::adjustments::{Adjustment, TimeAdjustment};
 use super::high_altitude_rule::HighLatitudeRule;
@@ -20,6 +22,7 @@ use super::prayer::Prayer;
 /// the parameters that are need.
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Parameters {
     pub method: Method,
     pub fajr_angle: f64,

--- a/src/models/parameters.rs
+++ b/src/models/parameters.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::adjustments::TimeAdjustment;
+use super::adjustments::TimeAdjustments;
 use super::high_altitude_rule::HighLatitudeRule;
 use super::madhab::Madhab;
 use super::method::Method;
@@ -30,8 +30,23 @@ pub struct Parameters {
     pub isha_interval: i32,
     pub madhab: Madhab,
     pub high_latitude_rule: HighLatitudeRule,
-    pub adjustments: TimeAdjustment,
-    pub method_adjustments: TimeAdjustment,
+    pub adjustments: TimeAdjustments,
+    pub method_adjustments: TimeAdjustments,
+}
+
+impl Default for Parameters {
+    fn default() -> Self {
+        Parameters {
+            fajr_angle: 0.,
+            isha_angle: 0.,
+            method: Method::Other,
+            isha_interval: 0,
+            madhab: Madhab::Shafi,
+            high_latitude_rule: HighLatitudeRule::MiddleOfTheNight,
+            adjustments: TimeAdjustments::default(),
+            method_adjustments: TimeAdjustments::default(),
+        }
+    }
 }
 
 impl Parameters {
@@ -39,13 +54,14 @@ impl Parameters {
         Parameters {
             fajr_angle,
             isha_angle,
-            method: Method::Other,
-            isha_interval: 0,
-            madhab: Madhab::Shafi,
-            high_latitude_rule: HighLatitudeRule::MiddleOfTheNight,
-            adjustments: TimeAdjustment::default(),
-            method_adjustments: TimeAdjustment::default(),
+            ..Default::default()
         }
+    }
+
+    pub fn with(method: Method, madhab: Madhab) -> Parameters {
+        let mut params = method.parameters();
+        params.madhab = madhab;
+        params
     }
 
     pub fn night_portions(&self) -> (f64, f64) {
@@ -56,7 +72,7 @@ impl Parameters {
         }
     }
 
-    pub fn time_adjustments(&self, prayer: Prayer) -> i64 {
+    pub fn time_adjustment(&self, prayer: Prayer) -> i64 {
         match prayer {
             Prayer::Fajr => self.adjustments.fajr + self.method_adjustments.fajr,
             Prayer::Sunrise => self.adjustments.sunrise + self.method_adjustments.sunrise,
@@ -65,85 +81,6 @@ impl Parameters {
             Prayer::Maghrib => self.adjustments.maghrib + self.method_adjustments.maghrib,
             Prayer::Isha => self.adjustments.isha + self.method_adjustments.isha,
             _ => 0,
-        }
-    }
-}
-
-/// A builder for the the [Parameters](struct.Parameters.html).
-///
-/// It is recommended that this is used for setting
-/// all parameters that are needed.
-pub struct Configuration {
-    method: Method,
-    fajr_angle: f64,
-    isha_angle: f64,
-    isha_interval: i32,
-    madhab: Madhab,
-    high_latitude_rule: HighLatitudeRule,
-    adjustments: TimeAdjustment,
-    method_adjustments: TimeAdjustment,
-}
-
-impl Configuration {
-    pub fn new(fajr_angle: f64, isha_angle: f64) -> Configuration {
-        Configuration {
-            fajr_angle,
-            isha_angle,
-            method: Method::Other,
-            isha_interval: 0,
-            madhab: Madhab::Shafi,
-            high_latitude_rule: HighLatitudeRule::MiddleOfTheNight,
-            adjustments: TimeAdjustment::default(),
-            method_adjustments: TimeAdjustment::default(),
-        }
-    }
-
-    pub fn with(method: Method, madhab: Madhab) -> Parameters {
-        let mut params = method.parameters();
-        params.madhab = madhab;
-
-        params
-    }
-
-    pub fn method(&mut self, method: Method) -> &mut Configuration {
-        self.method = method;
-        self
-    }
-
-    pub fn method_adjustments(&mut self, method_adjustments: TimeAdjustment) -> &mut Configuration {
-        self.method_adjustments = method_adjustments;
-        self
-    }
-
-    pub fn high_latitude_rule(
-        &mut self,
-        high_latitude_rule: HighLatitudeRule,
-    ) -> &mut Configuration {
-        self.high_latitude_rule = high_latitude_rule;
-        self
-    }
-
-    pub fn madhab(&mut self, madhab: Madhab) -> &mut Configuration {
-        self.madhab = madhab;
-        self
-    }
-
-    pub fn isha_interval(&mut self, isha_interval: i32) -> &mut Configuration {
-        self.isha_angle = 0.0;
-        self.isha_interval = isha_interval;
-        self
-    }
-
-    pub fn done(&self) -> Parameters {
-        Parameters {
-            fajr_angle: self.fajr_angle,
-            isha_angle: self.isha_angle,
-            method: self.method,
-            isha_interval: self.isha_interval,
-            madhab: self.madhab,
-            high_latitude_rule: self.high_latitude_rule,
-            adjustments: self.adjustments,
-            method_adjustments: self.method_adjustments,
         }
     }
 }
@@ -172,9 +109,12 @@ mod tests {
 
     #[test]
     fn calculated_night_portions_seventh_of_the_night() {
-        let params = Configuration::new(18.0, 18.0)
-            .high_latitude_rule(HighLatitudeRule::SeventhOfTheNight)
-            .done();
+        let params = Parameters {
+            fajr_angle: 18.,
+            isha_angle: 18.,
+            high_latitude_rule: HighLatitudeRule::SeventhOfTheNight,
+            ..Default::default()
+        };
 
         assert_eq!(params.night_portions().0, 1.0 / 7.0);
         assert_eq!(params.night_portions().1, 1.0 / 7.0);
@@ -182,9 +122,12 @@ mod tests {
 
     #[test]
     fn calculated_night_portions_twilight_angle() {
-        let params = Configuration::new(10.0, 15.0)
-            .high_latitude_rule(HighLatitudeRule::TwilightAngle)
-            .done();
+        let params = Parameters {
+            fajr_angle: 10.,
+            isha_angle: 15.,
+            high_latitude_rule: HighLatitudeRule::TwilightAngle,
+            ..Default::default()
+        };
 
         assert_eq!(params.night_portions().0, 10.0 / 60.0);
         assert_eq!(params.night_portions().1, 15.0 / 60.0);
@@ -192,7 +135,7 @@ mod tests {
 
     #[test]
     fn parameters_using_method_and_madhab() {
-        let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
+        let params = Parameters::with(Method::NorthAmerica, Madhab::Hanafi);
 
         assert_eq!(params.method, Method::NorthAmerica);
         assert_eq!(params.fajr_angle, 15.0);

--- a/src/models/parameters.rs
+++ b/src/models/parameters.rs
@@ -4,6 +4,9 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 use super::adjustments::{Adjustment, TimeAdjustment};
 use super::high_altitude_rule::HighLatitudeRule;
 use super::madhab::Madhab;
@@ -16,6 +19,7 @@ use super::prayer::Prayer;
 /// It is recommended to use [Configuration](struct.Configuration.html) to build
 /// the parameters that are need.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Parameters {
     pub method: Method,
     pub fajr_angle: f64,

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -4,7 +4,7 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
-use chrono::{DateTime, Datelike, Utc, Weekday};
+use chrono::{Datelike, Utc, Weekday};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -10,7 +10,7 @@ use serde::{Serialize, Deserialize};
 
 /// Names of all obligatory prayers,
 /// sunrise, and Qiyam.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Prayer {
     Fajr,

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Prayer {
+    QiyamYesterday,
     Fajr,
     Sunrise,
     Dhuhr,
@@ -41,7 +42,21 @@ impl Prayer {
             Prayer::Asr => String::from("Asr"),
             Prayer::Maghrib => String::from("Maghrib"),
             Prayer::Isha => String::from("Isha"),
-            Prayer::Qiyam => String::from("Qiyam"),
+            Prayer::Qiyam | Prayer::QiyamYesterday => String::from("Qiyam"),
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            Prayer::Fajr => Prayer::Sunrise,
+            Prayer::Sunrise => Prayer::Dhuhr,
+            Prayer::Dhuhr => Prayer::Asr,
+            Prayer::Asr => Prayer::Maghrib,
+            Prayer::Maghrib => Prayer::Isha,
+            Prayer::Isha => Prayer::Qiyam,
+            Prayer::Qiyam => Prayer::FajrTomorrow,
+            Prayer::QiyamYesterday => Prayer::Fajr,
+            Prayer::FajrTomorrow => unreachable!(),
         }
     }
 }

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -5,13 +5,16 @@
 //
 
 use chrono::{DateTime, Datelike, Utc, Weekday};
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Names of all obligatory prayers,
 /// sunrise, and Qiyam.
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Prayer {
     Fajr,
     Sunrise,

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -4,7 +4,7 @@
 // Copyright (c) 2019 Farhan Ahmed. All rights reserved.
 //
 
-use chrono::{Datelike, Utc, Weekday};
+use chrono::{Datelike, Local, Weekday};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
@@ -33,7 +33,7 @@ impl Prayer {
             Prayer::Fajr | Prayer::FajrTomorrow => String::from("Fajr"),
             Prayer::Sunrise => String::from("Sunrise"),
             Prayer::Dhuhr => {
-                if Utc::now().weekday() == Weekday::Fri {
+                if Local::now().weekday() == Weekday::Fri {
                     String::from("Jumua")
                 } else {
                     String::from("Dhuhr")
@@ -70,7 +70,7 @@ mod tests {
         assert_eq!(Prayer::Fajr.name(), "Fajr");
         assert_eq!(Prayer::Sunrise.name(), "Sunrise");
 
-        if Utc::now().weekday() == Weekday::Fri {
+        if Local::now().weekday() == Weekday::Fri {
             assert_eq!(Prayer::Dhuhr.name(), "Jumua");
         } else {
             assert_eq!(Prayer::Dhuhr.name(), "Dhuhr");

--- a/src/models/prayer.rs
+++ b/src/models/prayer.rs
@@ -5,10 +5,13 @@
 //
 
 use chrono::{DateTime, Datelike, Utc, Weekday};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 /// Names of all obligatory prayers,
 /// sunrise, and Qiyam.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Prayer {
     Fajr,
     Sunrise,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -10,8 +10,10 @@
 //! the prayer times.
 
 use chrono::{Date, DateTime, Datelike, Duration, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::astronomy::ops;
 use crate::astronomy::solar::SolarTime;
@@ -24,6 +26,7 @@ use crate::models::prayer::Prayer;
 /// prayers.
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PrayerTimes {
     fajr: DateTime<Utc>,
     sunrise: DateTime<Utc>,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -113,28 +113,6 @@ impl PrayerTimes {
         Duration::minutes((self.time(self.next()) - Local::now()).num_minutes())
     }
 
-    pub fn _prayer_at(&self, time: DateTime<Local>) -> Option<Prayer> {
-        if (self.fajr_tomorrow - time).num_seconds() <= 0 {
-            Some(Prayer::FajrTomorrow)
-        } else if (self.qiyam - time).num_seconds() <= 0 {
-            Some(Prayer::Qiyam)
-        } else if (self.isha - time).num_seconds() <= 0 {
-            Some(Prayer::Isha)
-        } else if (self.maghrib - time).num_seconds() <= 0 {
-            Some(Prayer::Maghrib)
-        } else if (self.asr - time).num_seconds() <= 0 {
-            Some(Prayer::Asr)
-        } else if (self.dhuhr - time).num_seconds() <= 0 {
-            Some(Prayer::Dhuhr)
-        } else if (self.sunrise - time).num_seconds() <= 0 {
-            Some(Prayer::Sunrise)
-        } else if (self.fajr - time).num_seconds() <= 0 {
-            Some(Prayer::Fajr)
-        } else {
-            Some(Prayer::QiyamYesterday)
-        }
-    }
-
     /// All time before Fajr returns `QiyamYesterday`
     /// After `FajrTomorrow` it `panic`s
     pub fn prayer_at(&self, time: DateTime<Local>) -> Prayer {
@@ -300,6 +278,30 @@ mod tests {
             .with_timezone(&Local);
 
         assert_eq!(times.prayer_at(current_prayer_time), Prayer::Sunrise);
+    }
+
+    #[test]
+    fn current_prayer_should_be_fajr_with_high_tz() {
+        // Given the above DateTime, the Fajr prayer is at 2015-07-12T08:42:00Z
+        let local_date = Local.ymd(2020, 10, 11);
+        let params = Parameters::with(Method::Karachi, Madhab::Hanafi);
+        let coordinates = Coordinates::new(24.383_144, 88.583_183);
+        let times = PrayerTimes::calculate(local_date, coordinates, params);
+        let current_prayer_time = local_date.and_hms(5, 0, 0);
+
+        assert_eq!(times.prayer_at(current_prayer_time), Prayer::Fajr);
+    }
+
+    #[test]
+    fn next_prayer_should_be_sunrise_with_high_tz() {
+        // Given the below DateTime, sunrise is at 2015-07-12T10:08:00Z
+        let local_date = Local.ymd(2020, 10, 11);
+        let params = Parameters::with(Method::Karachi, Madhab::Hanafi);
+        let coordinates = Coordinates::new(24.383_144, 88.583_183);
+        let times = PrayerTimes::calculate(local_date, coordinates, params);
+        let current_prayer_time = local_date.and_hms(5, 0, 0);
+
+        assert_eq!(times.prayer_at(current_prayer_time).next(), Prayer::Sunrise);
     }
 
     #[test]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -10,10 +10,6 @@
 //! the prayer times.
 
 use chrono::{Date, DateTime, Datelike, Duration, DurationRound, Local};
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
 use crate::astronomy::ops;
 use crate::astronomy::solar::SolarTime;
@@ -24,9 +20,7 @@ use crate::models::prayer::Prayer;
 
 /// A data struct to hold the timing for all
 /// prayers.
-#[derive(PartialEq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Debug, Clone)]
 pub struct PrayerTimes {
     fajr: DateTime<Local>,
     sunrise: DateTime<Local>,
@@ -55,7 +49,7 @@ impl PrayerTimes {
         let asr = solar_time.afternoon(parameters.madhab.shadow());
         let night = solar_time_tomorrow.sunrise - solar_time.sunset;
 
-        let fajr = PrayerTimes::calculate_fajr(parameters, solar_time, night, coordinates, date);
+        let fajr = PrayerTimes::calculate_fajr(parameters, &solar_time, night, coordinates, date);
         let sunrise =
             solar_time.sunrise + Duration::minutes(parameters.time_adjustment(Prayer::Sunrise));
         let dhuhr =
@@ -63,13 +57,13 @@ impl PrayerTimes {
         let asr = asr + Duration::minutes(parameters.time_adjustment(Prayer::Asr));
         let maghrib =
             solar_time.sunset + Duration::minutes(parameters.time_adjustment(Prayer::Maghrib));
-        let isha = PrayerTimes::calculate_isha(parameters, solar_time, night, coordinates, date);
+        let isha = PrayerTimes::calculate_isha(parameters, &solar_time, night, coordinates, date);
 
         // Calculate the middle of the night and qiyam times
         let (middle_of_the_night, qiyam, fajr_tomorrow) = PrayerTimes::calculate_qiyam(
             maghrib,
             parameters,
-            solar_time_tomorrow,
+            &solar_time_tomorrow,
             coordinates,
             tomorrow,
         );
@@ -167,7 +161,7 @@ impl PrayerTimes {
 
     fn calculate_fajr(
         parameters: Parameters,
-        solar_time: SolarTime,
+        solar_time: &SolarTime,
         night: Duration,
         coordinates: Coordinates,
         date: Date<Local>,
@@ -203,7 +197,7 @@ impl PrayerTimes {
 
     fn calculate_isha(
         parameters: Parameters,
-        solar_time: SolarTime,
+        solar_time: &SolarTime,
         night: Duration,
         coordinates: Coordinates,
         date: Date<Local>,
@@ -247,7 +241,7 @@ impl PrayerTimes {
     fn calculate_qiyam(
         current_maghrib: DateTime<Local>,
         parameters: Parameters,
-        solar_time: SolarTime,
+        solar_time: &SolarTime,
         coordinates: Coordinates,
         date: Date<Local>,
     ) -> (DateTime<Local>, DateTime<Local>, DateTime<Local>) {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -10,6 +10,8 @@
 //! the prayer times.
 
 use chrono::{Date, DateTime, Datelike, Duration, Local, NaiveDateTime, TimeZone, Timelike, Utc};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 use crate::astronomy::ops;
 use crate::astronomy::solar::SolarTime;
@@ -21,6 +23,7 @@ use crate::models::prayer::Prayer;
 /// A data struct to hold the timing for all
 /// prayers.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PrayerTimes {
     fajr: DateTime<Utc>,
     sunrise: DateTime<Utc>,


### PR DESCRIPTION
* fix `SolarTime::setting_hour` which failed with value < 0
* __move public API to use `Local` in stead of `Utc`__
* add `serde` and `schemars` features
* add missing exports (eg: `HighLatitudeRule`)
* remove builder pattern as the struct are so straightforward to be directly initialized
* update codebase to follow latest Rust standard