### PR TITLE
Fixed the Qiblah issue (`qiblah.0` is a private field) in other rust source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,57 +62,57 @@ The calculation of the prayer times requires certain pieces of information. Thes
 let params = Configuration::with(Method::NorthAmerica, Madhab::Hanafi);
 ```
 
-| Parameter | Description |
-| --------- | ----------- |
-| `method`    | Which preset from the CalculationMethod enum was used. Default value is `other`. |
-| `fajr_angle` | Angle of the sun below the horizon used to calculate Fajr. |
-| `maghrib_angle` | Angle of the sun below the horizon used to calculate Maghrib, used for some Calculation Methods. |
-| `isha_angle` | Angle of the sun below the horizon used to calculate Isha. |
-| `isha_interval` | Minutes after Maghrib (if set, the time for Isha will be Maghrib plus `isha_interval`). |
-| `madhab` | Which setting from the Madhab enum to use for calculating Asr. |
+| Parameter            | Description                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `method`             | Which preset from the CalculationMethod enum was used. Default value is `other`.                                             |
+| `fajr_angle`         | Angle of the sun below the horizon used to calculate Fajr.                                                                   |
+| `maghrib_angle`      | Angle of the sun below the horizon used to calculate Maghrib, used for some Calculation Methods.                             |
+| `isha_angle`         | Angle of the sun below the horizon used to calculate Isha.                                                                   |
+| `isha_interval`      | Minutes after Maghrib (if set, the time for Isha will be Maghrib plus `isha_interval`).                                      |
+| `madhab`             | Which setting from the Madhab enum to use for calculating Asr.                                                               |
 | `high_latitude_rule` | Which setting from the HighLatitudeRule enum to use for calculating the minimum time for Fajr and the maximum time for Isha. |
-| `adjustments` | PrayerAdjustments struct with custom prayer time adjustments in minutes for each prayer time. |
-| `rounding` | The behavior for rounding prayer times. Either to nearest minute, to the higher minute, or none.  |
-| `shafaq` | Used by the MoonsightingCommittee method to determine how to calculate Isha. See explanation of values below. |
+| `adjustments`        | PrayerAdjustments struct with custom prayer time adjustments in minutes for each prayer time.                                |
+| `rounding`           | The behavior for rounding prayer times. Either to nearest minute, to the higher minute, or none.                             |
+| `shafaq`             | Used by the MoonsightingCommittee method to determine how to calculate Isha. See explanation of values below.                |
 
 **Method**
 
 Provides preset configuration for a few authorities for calculating prayer times.
 
-| Value | Description |
-| ----- | ----------- |
-| `MuslimWorldLeague` | Muslim World League. Standard Fajr time with an angle of 18°. Earlier Isha time with an angle of 17°. |
-| `Egyptian` | Egyptian General Authority of Survey. Early Fajr time using an angle 19.5° and a slightly earlier Isha time using an angle of 17.5°. |
-| `Karachi` | University of Islamic Sciences, Karachi. A generally applicable method that uses standard Fajr and Isha angles of 18°. |
-| `UmmAlQura` | Umm al-Qura University, Makkah. Uses a fixed interval of 90 minutes from maghrib to calculate Isha. And a slightly earlier Fajr time with an angle of 18.5°. *Note: you should add a +30 minute custom adjustment for Isha during Ramadan.* |
-| `Dubai` | Used in the UAE. Slightly earlier Fajr time and slightly later Isha time with angles of 18.2° for Fajr and Isha in addition to 3 minute offsets for sunrise, Dhuhr, Asr, and Maghrib. |
-| `Qatar` | Same Isha interval as `ummAlQura` but with the standard Fajr time using an angle of 18°. |
-| `Kuwait` | Standard Fajr time with an angle of 18°. Slightly earlier Isha time with an angle of 17.5°. |
+| Value                   | Description                                                                                                                                                                                                                                                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MuslimWorldLeague`     | Muslim World League. Standard Fajr time with an angle of 18°. Earlier Isha time with an angle of 17°.                                                                                                                                                                                                           |
+| `Egyptian`              | Egyptian General Authority of Survey. Early Fajr time using an angle 19.5° and a slightly earlier Isha time using an angle of 17.5°.                                                                                                                                                                            |
+| `Karachi`               | University of Islamic Sciences, Karachi. A generally applicable method that uses standard Fajr and Isha angles of 18°.                                                                                                                                                                                          |
+| `UmmAlQura`             | Umm al-Qura University, Makkah. Uses a fixed interval of 90 minutes from maghrib to calculate Isha. And a slightly earlier Fajr time with an angle of 18.5°. _Note: you should add a +30 minute custom adjustment for Isha during Ramadan._                                                                     |
+| `Dubai`                 | Used in the UAE. Slightly earlier Fajr time and slightly later Isha time with angles of 18.2° for Fajr and Isha in addition to 3 minute offsets for sunrise, Dhuhr, Asr, and Maghrib.                                                                                                                           |
+| `Qatar`                 | Same Isha interval as `ummAlQura` but with the standard Fajr time using an angle of 18°.                                                                                                                                                                                                                        |
+| `Kuwait`                | Standard Fajr time with an angle of 18°. Slightly earlier Isha time with an angle of 17.5°.                                                                                                                                                                                                                     |
 | `MoonsightingCommittee` | Method developed by Khalid Shaukat, founder of Moonsighting Committee Worldwide. Uses standard 18° angles for Fajr and Isha in addition to seasonal adjustment values. This method automatically applies the 1/7 approximation rule for locations above 55° latitude. Recommended for North America and the UK. |
-| `Singapore` | Used in Singapore, Malaysia, and Indonesia. Early Fajr time with an angle of 20° and standard Isha time with an angle of 18°. |
-| `Turkey` | An approximation of the Diyanet method used in Turkey. This approximation is less accurate outside the region of Turkey. |
-| `Tehran` | Institute of Geophysics, University of Tehran. Early Isha time with an angle of 14°. Slightly later Fajr time with an angle of 17.7°. Calculates Maghrib based on the sun reaching an angle of 4.5° below the horizon. |
-| `NorthAmerica` | Also known as the ISNA method. Can be used for North America, but the moonsightingCommittee method is preferable. Gives later Fajr times and early Isha times with angles of 15°. |
-| `Other` | Defaults to angles of 0°, should generally be used for making a custom method and setting your own values. |
+| `Singapore`             | Used in Singapore, Malaysia, and Indonesia. Early Fajr time with an angle of 20° and standard Isha time with an angle of 18°.                                                                                                                                                                                   |
+| `Turkey`                | An approximation of the Diyanet method used in Turkey. This approximation is less accurate outside the region of Turkey.                                                                                                                                                                                        |
+| `Tehran`                | Institute of Geophysics, University of Tehran. Early Isha time with an angle of 14°. Slightly later Fajr time with an angle of 17.7°. Calculates Maghrib based on the sun reaching an angle of 4.5° below the horizon.                                                                                          |
+| `NorthAmerica`          | Also known as the ISNA method. Can be used for North America, but the moonsightingCommittee method is preferable. Gives later Fajr times and early Isha times with angles of 15°.                                                                                                                               |
+| `Other`                 | Defaults to angles of 0°, should generally be used for making a custom method and setting your own values.                                                                                                                                                                                                      |
 
 **Madhab**
 
 Setting for the Asr prayer time. For Hanafi madhab, the Asr is bit later than that of the Shafi madhab.
 
-| Value | Description |
-| ----- | ----------- |
-| `Shafi` | Earlier Asr time (use for Shafi, Maliki, Hanbali, and Jafari) |
-| `Hanafi` | Later Asr time |
+| Value    | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| `Shafi`  | Earlier Asr time (use for Shafi, Maliki, Hanbali, and Jafari) |
+| `Hanafi` | Later Asr time                                                |
 
 **HighLatitudeRule**
 
 Rule for approximating Fajr and Isha at high latitudes.
 
-| Value | Description |
-| ----- | ----------- |
-| `MiddleOfTheNight` | Fajr won't be earlier than the midpoint of the night and isha won't be later than the midpoint of the night. This is the default value to prevent fajr and isha crossing boundaries. |
+| Value               | Description                                                                                                                                                                                                                                                                         |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MiddleOfTheNight`  | Fajr won't be earlier than the midpoint of the night and isha won't be later than the midpoint of the night. This is the default value to prevent fajr and isha crossing boundaries.                                                                                                |
 | `SeventhOfTheNight` | Fajr will never be earlier than the beginning of the last seventh of the night and Isha will never be later than the end of the first seventh of the night. This is recommended to use for locations above 48° latitude to prevent prayer times that would be difficult to perform. |
-| `TwilightAngle` | The night is divided into portions of roughly 1/3. The exact value is derived by dividing the fajr/isha angles by 60. This can be used to prevent difficult fajr and isha times at certain locations. |
+| `TwilightAngle`     | The night is divided into portions of roughly 1/3. The exact value is derived by dividing the fajr/isha angles by 60. This can be used to prevent difficult fajr and isha times at certain locations.                                                                               |
 
 You can get the recommended High Latitude Rule for a location by calling the `recommended(coordinates:)` function and passing in the coordinates for the location.
 
@@ -125,16 +125,16 @@ let highLatRule = HighLatitudeRule::recommended(myCoordinates);
 
 Shafaq is used by the MoonsightingCommittee method to determine what type of twilight to use in order to determine the time for Isha.
 
-| Value | Description |
-| ----- | ----------- |
-| `General` | General is a combination of Ahmer and Abyad. This is the defualt value and will provide more reasonable times for locations at higher latitudes. |
-| `Ahmer` | Ahmer means the twilight is the red glow in the sky. Used by the Shafi, Maliki, and Hanbali madhabs. This generally produces an earlier Isha time. |
-| `Abyad` | Abyad means the twilight is the white glow in the sky. Used by the Hanafi madhab. This generally produces a later Isha time. |
+| Value     | Description                                                                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `General` | General is a combination of Ahmer and Abyad. This is the defualt value and will provide more reasonable times for locations at higher latitudes.   |
+| `Ahmer`   | Ahmer means the twilight is the red glow in the sky. Used by the Shafi, Maliki, and Hanbali madhabs. This generally produces an earlier Isha time. |
+| `Abyad`   | Abyad means the twilight is the white glow in the sky. Used by the Hanafi madhab. This generally produces a later Isha time.                       |
 
 ### Prayer Schedule
 
 The `PrayerSchedule` struct is a builder for the the `PrayerTimes` struct. Once the `calculate()` method is invoked on it, a `PrayerTime` struct will be initialized and it will contain fields
-for all five prayer times, the time for sunrise, and for the Qiyam prayer. 
+for all five prayer times, the time for sunrise, and for the Qiyam prayer.
 
 The prayer time will be an instance of `DateTime<Utc>` and as such will refer to a fixed point in universal time. To display these times for the local timezone you will need to format them with the appropriate local time zone.
 
@@ -142,17 +142,17 @@ This struct provides convenience methods for the prayer times to ease their usag
 
 **PrayerTime**
 
-| Method | Description |
-| ------ | ----------- |
-| `name()` | Returns the name of the payer transliterated in English. |
-| `time(prayer: Prayer)` | Returns the time of the prayer as a `DateTime<Utc>`. See the `DateTime` documentation for manipulating the return value. |
-| `current()` | Returns the current prayer as the `Prayer` type. |
-| `next()` | Returns the next prayer as the `Prayer` type. |
-| `time_remaining()` | Returns a tuple with the *hours* as its first element, and *minutes* as its second element. The value is always in the context of the current prayer. |
+| Method                 | Description                                                                                                                                           |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name()`               | Returns the name of the payer transliterated in English.                                                                                              |
+| `time(prayer: Prayer)` | Returns the time of the prayer as a `DateTime<Utc>`. See the `DateTime` documentation for manipulating the return value.                              |
+| `current()`            | Returns the current prayer as the `Prayer` type.                                                                                                      |
+| `next()`               | Returns the next prayer as the `Prayer` type.                                                                                                         |
+| `time_remaining()`     | Returns a tuple with the _hours_ as its first element, and _minutes_ as its second element. The value is always in the context of the current prayer. |
 
 **Prayer**
 
-This is an enum and has variants for all prayers, including, *sunrise* and *Qiyam*. This is single method available for this type called, `name()`, that will return the name of the prayer transliterated into English.
+This is an enum and has variants for all prayers, including, _sunrise_ and _Qiyam_. This is single method available for this type called, `name()`, that will return the name of the prayer transliterated into English.
 
 ## Full Example
 
@@ -217,11 +217,13 @@ println!("Next prayer is {} at {}.", prayers.next().name, prayers.time(prayer.ne
 
 Get the direction, in degrees from North, of the Qibla from a given set of coordinates.
 
+<!-- Updated Documentation -->
+
 ```rust
 let new_york_city   = Coordinates::new(40.7128, -74.0059);
-let qibla_direction = Qibla::new(coordinates: new_york_city);
+let qiblah_direction = Qiblah::new(coordinates: new_york_city);
 
-println!("Qiblah: {:?}", qibla_direction); //  Outputs: Qiblah: 58.4817
+println!("Qiblah: {:?}", qiblah_direction.0); //  Outputs: Qiblah: 58.4817
 ```
 
 ## Contributing

--- a/src/astronomy/qiblah.rs
+++ b/src/astronomy/qiblah.rs
@@ -6,7 +6,11 @@
 
 use crate::astronomy::unit::{Angle, Coordinates};
 
-pub struct Qiblah(f64);
+// Old
+// pub struct Qiblah(f64);
+
+// New
+pub struct Qiblah(pub f64);
 
 impl Qiblah {
     pub fn new(location_coordinates: Coordinates) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::high_altitude_rule::HighLatitudeRule;
+    use crate::{models::high_altitude_rule::HighLatitudeRule, prelude::Qiblah};
     use chrono::prelude::*;
 
     #[test]
@@ -281,5 +281,24 @@ mod tests {
             }
             Err(_err) => assert!(false),
         }
+    }
+
+    #[test]
+    fn check_for_qiblah_accessiblity_in_other_files() {
+        let city = Coordinates::new(23.7231, 90.4086);
+
+        let qiblah = Qiblah::new(city);
+
+        // Calling the field 0 of "qiblah" is private in the current crate
+        // "field `0` of struct `qiblah::Qiblah` is private" [rust_analyzer]
+        // Which makes it unaccessible from other files
+        // your tests ran perfectly as they are in the same file
+        // in my update I made the field public
+
+        // After making the field public in line 13 of astronomy/qiblah.rs file
+        // the following test will pass, InShaaAllah
+        assert_eq!(qiblah.0, 277.6480194680894);
+
+        // test tests::check_for_qiblah_accessiblity_in_other_files ... ok
     }
 }


### PR DESCRIPTION
When I was using your crate, I struggled to get the return value of the `Qiblah::new(coords)` which used to return an instance of `Qiblah(f64)` where f64 had the angle value. So tried to get the value by calling `qiblah_direction.0`, and rust analyzer gave me a private field error.

Therefore, I made the field public (i.e. from `pub struct Qiblah(f64);` to `pub struct Qiblah(pub f64);`) which made the difference...

Sir, I don't know if you liked this simple workaround, but that's the solution I came up with. You may improve it. I don't know if you will like it if I changed (enhanced) the structure entirely in my own way, so kept this much change only. I also changed the code example for Qiblah in the `README.md` file so that the code work even when copy-pasted.

That's all I wanted to say.

*P.S: Sorry for the extra bits and spaces in the README file in the tables part! That's my code formatter BTW...*

Best Regards,
Md. Riyasat Hossain